### PR TITLE
Add EBS extension for TypeScript compilation

### DIFF
--- a/.ebextensions/ts_compile.config
+++ b/.ebextensions/ts_compile.config
@@ -1,0 +1,6 @@
+# ts_compile.config
+container_commands:
+  compile:
+    command: "./node_modules/.bin/tsc -p tsconfig.json"
+    env:
+      PATH: /opt/elasticbeanstalk/node-install/node-v16.14.2-linux-x64/bin/


### PR DESCRIPTION
This PR adds an Elastic Beanstalk extension for compiling the TypeScript source when the API is deployed to AWS.