### PR TITLE
Creation of dummy students and improvements to state and measurement updates

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -446,3 +446,26 @@ export async function findClassByCode(code: string): Promise<Class | null> {
     where: { code: code }
   });
 }
+
+
+/** For testing purposes */
+export async function newDummyStudent(): Promise<Student> {
+  const students = await Student.findAll();
+  const ids: number[] = students.map(student => {
+    if (!student) { return 0; }
+    return typeof student.id === "number" ? student.id : 0;
+  });
+  const maxID = Math.max(...ids);
+  const newID = maxID + 1;
+  console.log(newID);
+  return Student.create({
+    username: `dummy_student_${newID}`,
+    verified: 1,
+    verification_code: `verification_${newID}`,
+    password: "dummypass",
+    institution: "Dummy",
+    email: `dummy_student_${newID}@dummy.school`,
+    age: null,
+    gender: null,
+  });
+}

--- a/src/database.ts
+++ b/src/database.ts
@@ -393,7 +393,7 @@ export async function getAllEducators(): Promise<Educator[]> {
 }
 
 export async function getStoryState(studentID: number, storyName: string): Promise<JSON | null> {
-  const result = await StoryState.findAll({
+  const result = await StoryState.findOne({
     where: {
       student_id: studentID,
       story_name: storyName
@@ -403,10 +403,32 @@ export async function getStoryState(studentID: number, storyName: string): Promi
     console.log(error);
     return null;
   });
-  if (result === null || result.length !== 1) {
+  return result?.story_state || null;
+}
+
+export async function updateStoryState(studentID: number, storyName: string, newState: JSON): Promise<JSON | null> {
+  let result = await StoryState.findOne({
+    where: {
+      student_id: studentID,
+      story_name: storyName
+    }
+  })
+  .catch(error => {
+    console.log(error);
     return null;
+  });
+
+  const storyData = {
+    student_id: studentID,
+    story_name: storyName,
+    story_state: newState
+  };
+  if (result !== null) {
+    result?.update(storyData);
+  } else {
+    result = await StoryState.create(storyData);
   }
-  return result[0].story_state;
+  return result?.story_state || null;
 }
 
 export async function getClassesForEducator(educatorID: number): Promise<Class[]> {
@@ -455,9 +477,7 @@ export async function newDummyStudent(): Promise<Student> {
     if (!student) { return 0; }
     return typeof student.id === "number" ? student.id : 0;
   });
-  const maxID = Math.max(...ids);
-  const newID = maxID + 1;
-  console.log(newID);
+  const newID = Math.max(...ids) + 1;
   return Student.create({
     username: `dummy_student_${newID}`,
     verified: 1,

--- a/src/database.ts
+++ b/src/database.ts
@@ -469,6 +469,12 @@ export async function findClassByCode(code: string): Promise<Class | null> {
   });
 }
 
+export async function getGalaxyByName(name: string): Promise<Galaxy | null> {
+  return Galaxy.findOne({
+    where: { name: name }
+  });
+}
+
 
 /** For testing purposes */
 export async function newDummyStudent(): Promise<Student> {

--- a/src/models/story_state.ts
+++ b/src/models/story_state.ts
@@ -12,6 +12,7 @@ export function initializeStoryStateModel(sequelize: Sequelize) {
       student_id: {
         type: DataTypes.INTEGER.UNSIGNED,
         allowNull: false,
+        primaryKey: true,
         references: {
           model: Student,
           key: "id"
@@ -19,7 +20,8 @@ export function initializeStoryStateModel(sequelize: Sequelize) {
       },
       story_name: {
         type: DataTypes.STRING,
-        allowNull: false
+        allowNull: false,
+        primaryKey: true
       },
       story_state: {
         type: DataTypes.JSON,

--- a/src/models/student_class.ts
+++ b/src/models/student_class.ts
@@ -3,36 +3,38 @@ import { Class } from "./class";
 import { Student } from "./student";
 
 export class StudentsClasses extends Model<InferAttributes<StudentsClasses>, InferCreationAttributes<StudentsClasses>> {
-    declare student_id: number;
-    declare class_id: number;
-    declare joined: CreationOptional<Date>;
+  declare student_id: number;
+  declare class_id: number;
+  declare joined: CreationOptional<Date>;
 }
 
 export function initializeStudentClassModel(sequelize: Sequelize) {
-    StudentsClasses.init({
-        student_id: {
-            type: DataTypes.INTEGER.UNSIGNED,
-            allowNull: false,
-            references: {
-                model: Student,
-                key: "id"
-            }
-        },
-        class_id: {
-            type: DataTypes.INTEGER.UNSIGNED,
-            allowNull: false,
-            references: {
-                model: Class,
-                key: "id"
-            }
-        },
-        joined: {
-            type: DataTypes.DATE,
-            allowNull: false,
-            defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
-        },
-    }, {
-        sequelize,
-        freezeTableName: true
-    });
+  StudentsClasses.init({
+    student_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Student,
+        key: "id"
+      }
+    },
+    class_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Class,
+        key: "id"
+      }
+    },
+    joined: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
+    },
+  }, {
+    sequelize,
+    freezeTableName: true
+  });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import {
   LoginResponse,
   getClassesForEducator,
   findClassByCode,
+  newDummyStudent,
 } from "./database";
 
 import {
@@ -340,5 +341,26 @@ app.get("/student-classes/:studentID", async (req, res) => {
   res.json({
     student_id: studentID,
     classes: classes
+  });
+});
+
+app.get("/logout", (req, res) => {
+  req.session.destroy(console.log);
+  res.send({
+    "logout": true
+  });
+});
+
+
+/** Testing Endpoints
+ * 
+ * These endpoints are intended for internal testing use only
+ * and will not be in the final version of the API
+ */
+
+app.get("/new-dummy-student", async (_req, res) => {
+  const student = await newDummyStudent();
+  res.json({
+    student: student
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import {
   findClassByCode,
   newDummyStudent,
   updateStoryState,
+  getGalaxyByName,
 } from "./database";
 
 import {
@@ -250,7 +251,7 @@ app.put("/submit-measurement", async (req, res) => {
   const data = req.body;
   const valid = (
     typeof data.student_id === "number" &&
-    typeof data.galaxy_id === "number" &&
+    ((typeof data.galaxy_id === "number") || (typeof data.galaxy_name === "string")) &&
     (!data.rest_wave_value || typeof data.rest_wave_value === "number") &&
     (!data.rest_wave_unit || typeof data.rest_wave_unit === "string") &&
     (!data.obs_wave_value || typeof data.obs_wave_value === "number") &&
@@ -262,6 +263,12 @@ app.put("/submit-measurement", async (req, res) => {
     (!data.est_dist_value || typeof data.est_dist_value === "number") &&
     (!data.est_dist_unit || typeof data.est_dist_unit === "string")
   );
+
+  if (typeof data.galaxy_id !== "number") {
+    const galaxy = await getGalaxyByName(data.galaxy_name);
+    data.galaxy_id = galaxy?.id || 0;
+    delete data.galaxy_name;
+  }
 
   let result: SubmitHubbleMeasurementResult;
   if (valid) {
@@ -329,7 +336,7 @@ app.put("/story-state/:studentID/:storyName", async (req, res) => {
   const params = req.params;
   const studentID = parseInt(params.studentID);
   const storyName = params.storyName;
-  const newState = req.body.storyState;
+  const newState = req.body;
   const state = await updateStoryState(studentID, storyName, newState);
   res.json({
     student_id: studentID,

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import {
   getClassesForEducator,
   findClassByCode,
   newDummyStudent,
+  updateStoryState,
 } from "./database";
 
 import {
@@ -312,11 +313,24 @@ app.get("/measurements/:studentID/:galaxyID", async (req, res) => {
   });
 });
 
-app.get("/story_state/:studentID/:storyName", async (req, res) => {
+app.get("/story-state/:studentID/:storyName", async (req, res) => {
   const params = req.params;
   const studentID = parseInt(params.studentID);
   const storyName = params.storyName;
   const state = await getStoryState(studentID, storyName);
+  res.json({
+    student_id: studentID,
+    story_name: storyName,
+    state: state
+  });
+});
+
+app.put("/story-state/:studentID/:storyName", async (req, res) => {
+  const params = req.params;
+  const studentID = parseInt(params.studentID);
+  const storyName = params.storyName;
+  const newState = req.body.storyState;
+  const state = await updateStoryState(studentID, storyName, newState);
   res.json({
     student_id: studentID,
     story_name: storyName,


### PR DESCRIPTION
This PR adds a `/new-dummy-student` endpoint that creates a new dummy student and returns the relevant information. The use case here is for generating test data for the app, and we'll probably want to remove this endpoint in the future. Additionally, the ability to update a story state via a PUT request has been added, as well as support for updating a measurement using a galaxy's name rather than its ID.