### PR TITLE
Allow marking galaxies as bad

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,12 @@
     "": {
       "dependencies": {
         "@types/body-parser": "^1.19.2",
+        "@types/cookie-parser": "^1.4.2",
         "@types/cors": "^2.8.12",
+        "@types/crypto-js": "^4.1.0",
         "@types/express": "^4.17.13",
+        "@types/express-session": "^1.17.4",
+        "@types/uuid": "^8.3.4",
         "body-parser": "^1.19.1",
         "connect-session-sequelize": "^7.1.3",
         "cookie-parser": "^1.4.6",
@@ -23,10 +27,6 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
-        "@types/cookie-parser": "^1.4.2",
-        "@types/crypto-js": "^4.1.0",
-        "@types/express-session": "^1.17.4",
-        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.19.0",
         "@typescript-eslint/parser": "^5.19.0",
         "eslint": "^8.13.0",
@@ -180,7 +180,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.2.tgz",
       "integrity": "sha512-uwcY8m6SDQqciHsqcKDGbo10GdasYsPCYkH3hVegj9qAah6pX5HivOnOuI3WYmyQMnOATV39zv/Ybs0bC/6iVg==",
-      "dev": true,
       "dependencies": {
         "@types/express": "*"
       }
@@ -193,8 +192,7 @@
     "node_modules/@types/crypto-js": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.0.tgz",
-      "integrity": "sha512-DCFfy/vh2lG6qHSGezQ+Sn2Ulf/1Mx51dqOdmOKyW5nMK3maLlxeS3onC7r212OnBM2pBR95HkAmAjjF08YkxQ==",
-      "dev": true
+      "integrity": "sha512-DCFfy/vh2lG6qHSGezQ+Sn2Ulf/1Mx51dqOdmOKyW5nMK3maLlxeS3onC7r212OnBM2pBR95HkAmAjjF08YkxQ=="
     },
     "node_modules/@types/debug": {
       "version": "4.1.7",
@@ -258,7 +256,6 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.4.tgz",
       "integrity": "sha512-7cNlSI8+oOBUHTfPXMwDxF/Lchx5aJ3ho7+p9jJZYVg9dVDJFh3qdMXmJtRsysnvS+C6x46k9DRYmrmCkE+MVg==",
-      "dev": true,
       "dependencies": {
         "@types/express": "*"
       }
@@ -306,8 +303,7 @@
     "node_modules/@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "dev": true
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.19.0",
@@ -4446,7 +4442,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.2.tgz",
       "integrity": "sha512-uwcY8m6SDQqciHsqcKDGbo10GdasYsPCYkH3hVegj9qAah6pX5HivOnOuI3WYmyQMnOATV39zv/Ybs0bC/6iVg==",
-      "dev": true,
       "requires": {
         "@types/express": "*"
       }
@@ -4459,8 +4454,7 @@
     "@types/crypto-js": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.0.tgz",
-      "integrity": "sha512-DCFfy/vh2lG6qHSGezQ+Sn2Ulf/1Mx51dqOdmOKyW5nMK3maLlxeS3onC7r212OnBM2pBR95HkAmAjjF08YkxQ==",
-      "dev": true
+      "integrity": "sha512-DCFfy/vh2lG6qHSGezQ+Sn2Ulf/1Mx51dqOdmOKyW5nMK3maLlxeS3onC7r212OnBM2pBR95HkAmAjjF08YkxQ=="
     },
     "@types/debug": {
       "version": "4.1.7",
@@ -4524,7 +4518,6 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.4.tgz",
       "integrity": "sha512-7cNlSI8+oOBUHTfPXMwDxF/Lchx5aJ3ho7+p9jJZYVg9dVDJFh3qdMXmJtRsysnvS+C6x46k9DRYmrmCkE+MVg==",
-      "dev": true,
       "requires": {
         "@types/express": "*"
       }
@@ -4572,8 +4565,7 @@
     "@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "dev": true
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.19.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
   },
   "dependencies": {
     "@types/body-parser": "^1.19.2",
+    "@types/cookie-parser": "^1.4.2",
     "@types/cors": "^2.8.12",
+    "@types/crypto-js": "^4.1.0",
     "@types/express": "^4.17.13",
+    "@types/express-session": "^1.17.4",
+    "@types/uuid": "^8.3.4",
     "body-parser": "^1.19.1",
     "connect-session-sequelize": "^7.1.3",
     "cookie-parser": "^1.4.6",
@@ -20,12 +24,8 @@
     "mysql2": "^2.3.3",
     "nanoid": "^3.3.2",
     "sequelize": "^6.16.1",
-    "uuid": "^8.3.2",
     "typescript": "^4.6.3",
-    "@types/cookie-parser": "^1.4.2",
-    "@types/crypto-js": "^4.1.0",
-    "@types/express-session": "^1.17.4",
-    "@types/uuid": "^8.3.4"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.19.0",

--- a/sql/galaxies_add_element.sql
+++ b/sql/galaxies_add_element.sql
@@ -1,0 +1,6 @@
+ALTER TABLE Galaxies
+ADD element varchar(10) NOT NULL DEFAULT "H-α"
+
+UPDATE Galaxies
+SET element = "Mg-I"
+WHERE type = "E";

--- a/src/database.ts
+++ b/src/database.ts
@@ -457,9 +457,7 @@ export async function getClassesForStudent(studentID: number): Promise<Class[]> 
 
 export async function deleteClass(id: number): Promise<number> {
   return Class.destroy({
-    where: {
-      id: id
-    }
+    where: { id: id }
   });
 }
 
@@ -473,6 +471,10 @@ export async function getGalaxyByName(name: string): Promise<Galaxy | null> {
   return Galaxy.findOne({
     where: { name: name }
   });
+}
+
+export async function markGalaxyBad(galaxy: Galaxy): Promise<void> {
+  galaxy.update({ marked_bad: 1});
 }
 
 

--- a/src/models/galaxy.ts
+++ b/src/models/galaxy.ts
@@ -7,6 +7,8 @@ export class Galaxy extends Model<InferAttributes<Galaxy>, InferCreationAttribut
   declare decl: number;
   declare z: number;
   declare type: string;
+  declare element: string;
+  declare marked_bad: number;
 }
 
 export function initializeGalaxyModel(sequelize: Sequelize) {
@@ -37,6 +39,14 @@ export function initializeGalaxyModel(sequelize: Sequelize) {
     },
     type: {
       type: DataTypes.STRING,
+      allowNull: false
+    },
+    element: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    marked_bad: {
+      type: DataTypes.TINYINT,
       allowNull: false
     }
   }, {

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import {
   newDummyStudent,
   updateStoryState,
   getGalaxyByName,
+  markGalaxyBad,
 } from "./database";
 
 import {
@@ -38,6 +39,7 @@ import session from "express-session";
 import sequelizeStore from "connect-session-sequelize";
 import { v4 } from "uuid";
 import cors from "cors";
+import { Galaxy } from "./models/galaxy";
 const app = express();
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -372,6 +374,36 @@ app.get("/logout", (req, res) => {
   });
 });
 
+app.put("/mark-galaxy-bad", async (req, res) => {
+  const galaxyID = req.body.galaxy_id;
+  const galaxyName = req.body.galaxy_name;
+  if (!(galaxyID || galaxyName)) { 
+    res.status(400).json({
+      status: "missing_id_or_name"
+    });
+    return;
+   }
+
+  let galaxy: Galaxy | null;
+  if (galaxyID) {
+    galaxy = await Galaxy.findOne({ where: { id : galaxyID }});
+  } else {
+    galaxy = await getGalaxyByName(galaxyName);
+  }
+
+  if (galaxy === null) {
+    res.status(404).json({
+      status: "no_such_galaxy"
+    });
+    return;
+  }
+
+  markGalaxyBad(galaxy);
+  res.status(200).json({
+    status: "galaxy_marked_bad"
+  });
+
+});
 
 /** Testing Endpoints
  * 


### PR DESCRIPTION
This PR adds an endpoint to allow users to flag galaxies with no SDSS image data as bad. We can then manually verify and remove these galaxies later.