### PR TITLE
Update galaxy SQL

### DIFF
--- a/sql/create_galaxy_table.sql
+++ b/sql/create_galaxy_table.sql
@@ -5,6 +5,8 @@ CREATE TABLE Galaxies(
     decl FLOAT NOT NULL,
     z FLOAT NOT NULL,
     type varchar(10) NOT NULL,
+    element varchar(10) NOT NULL DEFAULT "H-α",
+    marked_bad tinyint(2) NOT NULL DEFAULT 0,
 
     PRIMARY KEY(id)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;


### PR DESCRIPTION
This PR is strictly bookkeeping. The definition of the galaxy table was altered to add `element` and `marked_bad` columns, so I've updated the SQL script that creates the galaxy table to match the new schema. The idea here is that these scripts can be used to recreate the tables if it's ever necessary. Note that this has no effect on the functioning of the API itself.