### PR TITLE
Track number of times galaxy marked bad

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -474,7 +474,7 @@ export async function getGalaxyByName(name: string): Promise<Galaxy | null> {
 }
 
 export async function markGalaxyBad(galaxy: Galaxy): Promise<void> {
-  galaxy.update({ marked_bad: 1});
+  galaxy.update({ marked_bad: galaxy.marked_bad + 1 });
 }
 
 


### PR DESCRIPTION
This PR updates the API to keep track of how many times a galaxy has been marked as "bad" (missing SDSS imagery) by users. Previously, this value was restricted to either be 0 or 1.