### PR TITLE
Change password to be environment variable

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -39,7 +39,7 @@ export type CreateClassResponse = {
   class?: object;
 }
 
-export const cosmicdsDB = new Sequelize("cosmicds_db", "cdsadmin", "5S4R1qCxzQg0", {
+export const cosmicdsDB = new Sequelize("cosmicds_db", "cdsadmin", process.env.DB_PASSWORD, {
     host: "cosmicds-db.cupwuw3jvfpc.us-east-1.rds.amazonaws.com",
     dialect: "mysql",
     define: {


### PR DESCRIPTION
This PR changes the database password (which has been changed) in the code from a string literal to the environment variable `DB_PASSWORD`. This variable is set in our Elastic Beanstalk environment on AWS.