### PR TITLE
Omit bad galaxies

### DIFF
--- a/sql/create_galaxy_table.sql
+++ b/sql/create_galaxy_table.sql
@@ -7,6 +7,7 @@ CREATE TABLE Galaxies(
     type varchar(10) NOT NULL,
     element varchar(10) NOT NULL DEFAULT "H-α",
     marked_bad tinyint(2) NOT NULL DEFAULT 0,
+    is_bad tinyint(2) NOT NULL DEFAULT 0,
 
     PRIMARY KEY(id)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;

--- a/src/database.ts
+++ b/src/database.ts
@@ -399,7 +399,9 @@ export async function getStudentHubbleMeasurements(studentID: number): Promise<H
 }
 
 export async function getAllGalaxies(): Promise<Galaxy[]> {
-  return Galaxy.findAll();
+  return Galaxy.findAll({
+    where: { is_bad: 0 }
+  });
 }
 
 export async function getAllStudents(): Promise<Student[]> {

--- a/src/models/galaxy.ts
+++ b/src/models/galaxy.ts
@@ -9,6 +9,7 @@ export class Galaxy extends Model<InferAttributes<Galaxy>, InferCreationAttribut
   declare type: string;
   declare element: string;
   declare marked_bad: number;
+  declare is_bad: number;
 }
 
 export function initializeGalaxyModel(sequelize: Sequelize) {
@@ -48,6 +49,10 @@ export function initializeGalaxyModel(sequelize: Sequelize) {
     marked_bad: {
       type: DataTypes.TINYINT,
       allowNull: false
+    },
+    is_bad: {
+      type:DataTypes.TINYINT,
+      allowNull: false,
     }
   }, {
     sequelize,


### PR DESCRIPTION
This PR modifies the `/galaxies` endpoint to omit galaxies that we have confirmed are "bad" (missing SDSS imagery).