### PR TITLE
Add dotenv for local environment variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "crypto-js": "^4.1.1",
+        "dotenv": "^16.0.0",
         "express": "^4.17.2",
         "express-cookie": "^4.17.1",
         "express-session": "^1.17.2",
@@ -1329,6 +1330,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dottie": {
@@ -5332,6 +5341,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
     },
     "dottie": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "crypto-js": "^4.1.1",
+    "dotenv": "^16.0.0",
     "express": "^4.17.2",
     "express-cookie": "^4.17.1",
     "express-session": "^1.17.2",

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,4 +1,6 @@
 import { Model, Op, Sequelize } from "sequelize";
+import dotenv from "dotenv";
+
 import { Class, initializeClassModel } from "./models/class";
 import { Educator, initializeEducatorModel } from "./models/educator";
 import { Student, initializeStudentModel } from "./models/student";
@@ -23,7 +25,7 @@ import { User } from "./user";
 import { Galaxy, initializeGalaxyModel } from "./models/galaxy";
 import { initializeStoryStateModel, StoryState } from "./models/story_state";
 import { ClassStories, initializeClassStoryModel } from "./models/story_class";
-import { initializeStoryModel, Story } from "./models/story";
+import { initializeStoryModel } from "./models/story";
 import { setUpAssociations } from "./associations";
 
 type SequelizeError = { parent: { code: string } };
@@ -38,6 +40,10 @@ export type CreateClassResponse = {
   result: CreateClassResult;
   class?: object;
 }
+
+// Grab any environment variables
+// Currently, just the DB password
+dotenv.config();
 
 export const cosmicdsDB = new Sequelize("cosmicds_db", "cdsadmin", process.env.DB_PASSWORD, {
     host: "cosmicds-db.cupwuw3jvfpc.us-east-1.rds.amazonaws.com",


### PR DESCRIPTION
This PR adds `dotenv` and reads from a local `.env` file to allow for running the API locally (provided that one has the login credentials).