### PR TITLE
Updates for seeding data

### DIFF
--- a/sql/create_galaxy_table.sql
+++ b/sql/create_galaxy_table.sql
@@ -8,6 +8,7 @@ CREATE TABLE Galaxies(
     element varchar(10) NOT NULL DEFAULT "H-α",
     marked_bad tinyint(2) NOT NULL DEFAULT 0,
     is_bad tinyint(2) NOT NULL DEFAULT 0,
+    spec_marked_bad int NOT NULL DEFAULT 0,
 
     PRIMARY KEY(id)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;

--- a/sql/create_galaxy_table.sql
+++ b/sql/create_galaxy_table.sql
@@ -9,6 +9,7 @@ CREATE TABLE Galaxies(
     marked_bad tinyint(2) NOT NULL DEFAULT 0,
     is_bad tinyint(2) NOT NULL DEFAULT 0,
     spec_marked_bad int NOT NULL DEFAULT 0,
+    spec_is_bad tinyint(2) NOT NULL DEFAULT 0,
 
     PRIMARY KEY(id)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;

--- a/sql/create_student_table.sql
+++ b/sql/create_student_table.sql
@@ -15,6 +15,8 @@ CREATE TABLE Students (
     visits int(11) NOT NULL DEFAULT 0,
     last_visit datetime NOT NULL,
     last_visit_ip varchar(50) COLLATE utf8_unicode_ci,
+    seed tinyint(2) NOT NULL DEFAULT 0,
+    team_member varchar(30)
 
     PRIMARY KEY(id),
     INDEX(username),

--- a/src/database.ts
+++ b/src/database.ts
@@ -519,6 +519,10 @@ export async function markGalaxyBad(galaxy: Galaxy): Promise<void> {
   galaxy.update({ marked_bad: galaxy.marked_bad + 1 });
 }
 
+export async function markGalaxySpectrumBad(galaxy: Galaxy): Promise<void> {
+  galaxy.update({ spec_marked_bad: galaxy.spec_marked_bad + 1 });
+}
+
 export async function getRosterInfoForStory(classID: number, storyName: string): Promise<StoryState[]> {
   return StudentsClasses.findAll({
     where: { class_id: classID }
@@ -552,7 +556,7 @@ export async function getRosterInfo(classID: number): Promise<Record<string,Stor
 }
 
 /** For testing purposes */
-export async function newDummyStudent(): Promise<Student> {
+export async function newDummyStudent(seed = false, teamMember: string | null = null): Promise<Student> {
   const students = await Student.findAll();
   const ids: number[] = students.map(student => {
     if (!student) { return 0; }
@@ -568,5 +572,7 @@ export async function newDummyStudent(): Promise<Student> {
     email: `dummy_student_${newID}@dummy.school`,
     age: null,
     gender: null,
+    seed: seed ? 1 : 0,
+    team_member: teamMember
   });
 }

--- a/src/models/galaxy.ts
+++ b/src/models/galaxy.ts
@@ -8,9 +8,10 @@ export class Galaxy extends Model<InferAttributes<Galaxy>, InferCreationAttribut
   declare z: number;
   declare type: string;
   declare element: string;
-  declare marked_bad: number;
-  declare spec_marked_bad: number;
-  declare is_bad: number;
+  declare marked_bad: CreationOptional<number>;
+  declare is_bad: CreationOptional<number>;
+  declare spec_marked_bad: CreationOptional<number>;
+  declare spec_is_bad: CreationOptional<number>;
 }
 
 export function initializeGalaxyModel(sequelize: Sequelize) {
@@ -57,6 +58,10 @@ export function initializeGalaxyModel(sequelize: Sequelize) {
     },
     spec_marked_bad: {
       type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    spec_is_bad: {
+      type: DataTypes.TINYINT,
       allowNull: false
     }
   }, {

--- a/src/models/galaxy.ts
+++ b/src/models/galaxy.ts
@@ -9,6 +9,7 @@ export class Galaxy extends Model<InferAttributes<Galaxy>, InferCreationAttribut
   declare type: string;
   declare element: string;
   declare marked_bad: number;
+  declare spec_marked_bad: number;
   declare is_bad: number;
 }
 
@@ -53,6 +54,10 @@ export function initializeGalaxyModel(sequelize: Sequelize) {
     is_bad: {
       type:DataTypes.TINYINT,
       allowNull: false,
+    },
+    spec_marked_bad: {
+      type: DataTypes.INTEGER,
+      allowNull: false
     }
   }, {
     sequelize,

--- a/src/models/student.ts
+++ b/src/models/student.ts
@@ -18,6 +18,8 @@ export class Student extends Model<InferAttributes<Student>, InferCreationAttrib
   declare visits: CreationOptional<number>;
   declare last_visit: CreationOptional<Date>;
   declare last_visit_ip: CreationOptional<string | null>;
+  declare seed: CreationOptional<number>;
+  declare team_member: CreationOptional<string | null>;
 }
 
 export function initializeStudentModel(sequelize: Sequelize) {
@@ -86,6 +88,13 @@ export function initializeStudentModel(sequelize: Sequelize) {
       defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
     },
     last_visit_ip: {
+      type: DataTypes.STRING
+    },
+    seed: {
+      type: DataTypes.TINYINT,
+      allowNull: false
+    },
+    team_member: {
       type: DataTypes.STRING
     }
   }, {

--- a/src/server.ts
+++ b/src/server.ts
@@ -396,7 +396,7 @@ app.get("/logout", (req, res) => {
   });
 });
 
-async function markBad(req: GenericRequest, res: GenericResponse, marker: (galaxy: Galaxy) => Promise<void>) {
+async function markBad(req: GenericRequest, res: GenericResponse, marker: (galaxy: Galaxy) => Promise<void>, markedStatus: string) {
   const galaxyID = req.body.galaxy_id;
   const galaxyName = req.body.galaxy_name;
   if (!(galaxyID || galaxyName)) { 
@@ -422,17 +422,17 @@ async function markBad(req: GenericRequest, res: GenericResponse, marker: (galax
 
   marker(galaxy);
   res.status(200).json({
-    status: "galaxy_marked_bad"
+    status: markedStatus
   });
 }
 
 /** Really should be POST */
 app.put("/mark-galaxy-bad", async (req, res) => {
-  markBad(req, res, markGalaxyBad);
+  markBad(req, res, markGalaxyBad, "galaxy_marked_bad");
 });
 
 app.post("/mark-spectrum-bad", async (req, res) => {
-  markBad(req, res, markGalaxySpectrumBad);
+  markBad(req, res, markGalaxySpectrumBad, "galaxy_spectrum_marked_bad");
 });
 
 /** Testing Endpoints


### PR DESCRIPTION
This PR contains the updates that we need for creating seed data for the Hubble database. Changes include:
* Add `spec_marked_bad` and `spec_is_bad` fields to the galaxy table and model
* Add `/mark-spectrum-bad` endpoint
* Add `seed` and `team_member` fields to the student table and model. These identify the entries that are being used to seed data, and which team member generated the data values.