### PR TITLE
Timestamp declarations

### DIFF
--- a/sql/create_hubble_measurements_table.sql
+++ b/sql/create_hubble_measurements_table.sql
@@ -12,6 +12,8 @@ CREATE TABLE HubbleMeasurements (
     ang_size_unit varchar(20),
     est_dist_value int(11),
     est_dist_unit varchar(20),
+    last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ON UPDATE CURRENT_TIMESTAMP,
 
     PRIMARY KEY(student_id, galaxy_id),
     INDEX(student_id),

--- a/sql/create_story_states_table.sql
+++ b/sql/create_story_states_table.sql
@@ -2,6 +2,8 @@ CREATE TABLE StoryStates (
     student_id int(11) UNSIGNED NOT NULL,
     story_name varchar(50) NOT NULL,
     story_state JSON NOT NULL,
+    last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ON UPDATE CURRENT_TIMESTAMP,
 
     PRIMARY KEY(student_id, story_name),
     INDEX(student_id),

--- a/src/database.ts
+++ b/src/database.ts
@@ -388,6 +388,9 @@ export async function getHubbleMeasurement(studentID: number, galaxyID: number):
         { galaxy_id: galaxyID }
       ]
     }
+  }).catch(error => {
+    console.log(error);
+    return null;
   });
 }
 
@@ -452,7 +455,10 @@ export async function updateStoryState(studentID: number, storyName: string, new
   if (result !== null) {
     result?.update(storyData);
   } else {
-    result = await StoryState.create(storyData);
+    result = await StoryState.create(storyData).catch(error => {
+      console.log(error);
+      return null;
+    });
   }
   return result?.story_state || null;
 }

--- a/src/models/hubble_measurement.ts
+++ b/src/models/hubble_measurement.ts
@@ -16,6 +16,7 @@ export class HubbleMeasurement extends Model<InferAttributes<HubbleMeasurement>,
   declare ang_size_unit: CreationOptional<string | null>;
   declare est_dist_value: CreationOptional<number | null>;
   declare est_dist_unit: CreationOptional<string | null>;
+  declare last_modified: CreationOptional<Date>;
 }
 
 export function initializeHubbleMeasurementModel(sequelize: Sequelize) {
@@ -68,6 +69,11 @@ export function initializeHubbleMeasurementModel(sequelize: Sequelize) {
     est_dist_unit: {
       type: DataTypes.STRING
     },
+    last_modified: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
+    }
   }, {
     sequelize,
     engine: "InnoDB"

--- a/src/models/story_state.ts
+++ b/src/models/story_state.ts
@@ -6,6 +6,7 @@ export class StoryState extends Model<InferAttributes<StoryState>, InferCreation
   declare student_id: CreationOptional<number>;
   declare story_name: string;
   declare story_state: JSON;
+  declare last_modified: CreationOptional<Date>;
 }
 
 export function initializeStoryStateModel(sequelize: Sequelize) {
@@ -31,6 +32,11 @@ export function initializeStoryStateModel(sequelize: Sequelize) {
       story_state: {
         type: DataTypes.JSON,
         allowNull: false
+      },
+      last_modified: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
       }
   }, {
     sequelize,


### PR DESCRIPTION
This PR updates the measurement and story state models to include the newly-added timestamp columns. The table definitions in the SQL files have been updated as well. Some trivial error handling was also added in `updateStoryState` and `getHubbleMeasurement`.