### PR TITLE
Updates for roster data endpoint

### DIFF
--- a/sql/create_story_table.sql
+++ b/sql/create_story_table.sql
@@ -1,6 +1,7 @@
 CREATE TABLE Stories (
     id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
     name varchar(32) NOT NULL UNIQUE,
+    display_name varchar(32) NOT NULL UNIQUE,
 
     PRIMARY KEY(id),
     INDEX(name)

--- a/src/associations.ts
+++ b/src/associations.ts
@@ -37,16 +37,31 @@ export function setUpAssociations() {
     onDelete: "CASCADE"
   });
 
-  Student.belongsTo(StoryState, {
-    foreignKey: "id",
-    targetKey: "student_id",
-    as: "story_state"
+  Student.hasMany(StoryState, {
+    foreignKey: "student_id"
+  });
+  StoryState.belongsTo(Student, {
+    as: "student",
+    targetKey: "id",
+    foreignKey: "student_id"
   });
 
-  StoryState.belongsTo(Student, {
-    foreignKey: "student_id",
-    targetKey: "id",
-    as: "student"
+  Story.hasMany(StoryState, {
+    foreignKey: "story_name"
+  });
+  StoryState.belongsTo(Story, {
+    as: "story",
+    targetKey: "name",
+    foreignKey: "story_name"
+  });
+  
+  Story.hasMany(ClassStories, {
+    foreignKey: "story_name"
+  });
+  ClassStories.belongsTo(Story, {
+    as: "story",
+    targetKey: "name",
+    foreignKey: "story_name"
   });
 
 }

--- a/src/models/story.ts
+++ b/src/models/story.ts
@@ -2,7 +2,8 @@ import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, 
 
 export class Story extends Model<InferAttributes<Story>, InferCreationAttributes<Story>> {
   declare id: CreationOptional<number>;
-  declare name: string; 
+  declare name: string;
+  declare display_name: string;
 }
 
 export function initializeStoryModel(sequelize: Sequelize) {
@@ -14,6 +15,11 @@ export function initializeStoryModel(sequelize: Sequelize) {
       primaryKey: true
     },
     name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
+    display_name: {
       type: DataTypes.STRING,
       allowNull: false,
       unique: true


### PR DESCRIPTION
This PR contains some updates aimed at making the roster data endpoint more useful for the website. In particular, a `display_name` field has been added to the story table in the database, and this updates the endpoint functionality so that the website can use this field.