### PR TITLE
Add endpoint for removing a measurement

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -2,20 +2,7 @@ import { Op } from "sequelize";
 import { HubbleMeasurement, initializeHubbleMeasurementModel } from "./models/hubble_measurement";
 import { cosmicdsDB, findStudentById } from "../../database";
 import { Galaxy, initializeGalaxyModel } from "./models/galaxy";
-
-export enum SubmitHubbleMeasurementResult {
-  BadRequest = "bad_request",
-  MeasurementCreated = "measurement_created",
-  MeasurementUpdated = "measurement_updated",
-  NoSuchStudent = "no_such_student"
-}
-
-export namespace SubmitHubbleMeasurementResult {
-  export function success(result: SubmitHubbleMeasurementResult): boolean {
-    return result === SubmitHubbleMeasurementResult.MeasurementCreated ||
-      result == SubmitHubbleMeasurementResult.MeasurementUpdated;
-  }
-}
+import { RemoveHubbleMeasurementResult, SubmitHubbleMeasurementResult } from "./request_results";
 
 initializeGalaxyModel(cosmicdsDB);
 initializeHubbleMeasurementModel(cosmicdsDB);
@@ -32,7 +19,7 @@ export async function submitHubbleMeasurement(data: {
   ang_size_value: number | null,
   ang_size_unit: string | null,
   est_dist_value: number | null,
-  est_dist_init: string | null
+  est_dist_unit: string | null
 }): Promise<SubmitHubbleMeasurementResult> {
 
   const student = await findStudentById(data.student_id);
@@ -92,6 +79,16 @@ export async function getStudentHubbleMeasurements(studentID: number): Promise<H
     return null;
   });
   return result;
+}
+
+export async function removeHubbleMeasurement(studentID: number, galaxyID: number): Promise<RemoveHubbleMeasurementResult> {
+  const count = await HubbleMeasurement.destroy({
+    where: {
+      student_id: studentID,
+      galaxy_id: galaxyID
+    }
+  });
+  return count > 0 ? RemoveHubbleMeasurementResult.MeasurementDeleted : RemoveHubbleMeasurementResult.NoSuchMeasurement;
 }
 
 export async function getAllGalaxies(): Promise<Galaxy[]> {

--- a/src/stories/hubbles_law/request_results.ts
+++ b/src/stories/hubbles_law/request_results.ts
@@ -1,0 +1,25 @@
+export enum SubmitHubbleMeasurementResult {
+  BadRequest = "bad_request",
+  MeasurementCreated = "measurement_created",
+  MeasurementUpdated = "measurement_updated",
+  NoSuchStudent = "no_such_student"
+}
+
+export namespace SubmitHubbleMeasurementResult {
+  export function success(result: SubmitHubbleMeasurementResult): boolean {
+    return result === SubmitHubbleMeasurementResult.MeasurementCreated ||
+      result == SubmitHubbleMeasurementResult.MeasurementUpdated;
+  }
+}
+
+export enum RemoveHubbleMeasurementResult {
+  BadRequest = "bad_request",
+  MeasurementDeleted = "measurement_deleted",
+  NoSuchMeasurement = "no_such_measurement"
+}
+
+export namespace RemoveHubbleMeasurementResult {
+  export function success(result: RemoveHubbleMeasurementResult): boolean {
+    return result === RemoveHubbleMeasurementResult.MeasurementDeleted;
+  }
+}

--- a/src/stories/hubbles_law/request_results.ts
+++ b/src/stories/hubbles_law/request_results.ts
@@ -22,4 +22,15 @@ export namespace RemoveHubbleMeasurementResult {
   export function success(result: RemoveHubbleMeasurementResult): boolean {
     return result === RemoveHubbleMeasurementResult.MeasurementDeleted;
   }
+
+  export function statusCode(result: RemoveHubbleMeasurementResult): number {
+    switch (result) {
+      case RemoveHubbleMeasurementResult.BadRequest:
+        return 400;
+      case RemoveHubbleMeasurementResult.MeasurementDeleted:
+        return 200;
+      case RemoveHubbleMeasurementResult.NoSuchMeasurement:
+        return 404;
+    }
+  }
 }

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -6,7 +6,6 @@ import {
 } from "../../server";
 
 import {
-  SubmitHubbleMeasurementResult,
   getGalaxyByName,
   getAllGalaxies,
   markGalaxyBad,
@@ -14,7 +13,13 @@ import {
   getHubbleMeasurement,
   submitHubbleMeasurement,
   getStudentHubbleMeasurements,
+  removeHubbleMeasurement
 } from "./database";
+
+import { 
+  RemoveHubbleMeasurementResult,
+  SubmitHubbleMeasurementResult
+} from "./request_results";
 
 import { Router } from "express";
 
@@ -53,6 +58,30 @@ router.put("/submit-measurement", async (req, res) => {
     measurement: data,
     status: result,
     success: SubmitHubbleMeasurementResult.success(result)
+  });
+});
+
+router.post("/remove-measurement", async (req, res) => {
+  const data = req.body;
+  const valid = typeof data.student_id === "number" &&
+    (typeof data.galaxy_id === "number" || typeof data.galaxy_name === "string");
+  if (typeof data.galaxy_id !== "number") {
+    const galaxy = await getGalaxyByName(data.galaxy_name);
+    data.galaxy_id = galaxy?.id || 0;
+    delete data.galaxy_name;
+  }
+
+  let result: RemoveHubbleMeasurementResult;
+  if (valid) {
+    result = await removeHubbleMeasurement(data.student_id, data.galaxy_id);
+  } else {
+    result = RemoveHubbleMeasurementResult.BadRequest;
+  }
+  res.json({
+    student_id: data.student_id,
+    galaxy_id: data.galaxy_id,
+    status: result,
+    success: RemoveHubbleMeasurementResult.success(result)
   });
 });
 
@@ -113,7 +142,10 @@ async function markBad(req: GenericRequest, res: GenericResponse, marker: (galax
   });
 }
 
-/** Really should be POST */
+/**
+ * Really should be POST
+ * This was previously idempotent, but no longer is
+ */
 router.put("/mark-galaxy-bad", async (req, res) => {
   markBad(req, res, markGalaxyBad, "galaxy_marked_bad");
 });

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -61,7 +61,7 @@ router.put("/submit-measurement", async (req, res) => {
   });
 });
 
-router.post("/remove-measurement", async (req, res) => {
+router.delete("/measurement", async (req, res) => {
   const data = req.body;
   const valid = typeof data.student_id === "number" &&
     (typeof data.galaxy_id === "number" || typeof data.galaxy_name === "string");
@@ -77,12 +77,13 @@ router.post("/remove-measurement", async (req, res) => {
   } else {
     result = RemoveHubbleMeasurementResult.BadRequest;
   }
-  res.json({
-    student_id: data.student_id,
-    galaxy_id: data.galaxy_id,
-    status: result,
-    success: RemoveHubbleMeasurementResult.success(result)
-  });
+  res.status(RemoveHubbleMeasurementResult.statusCode(result))
+    .json({
+      student_id: data.student_id,
+      galaxy_id: data.galaxy_id,
+      status: result,
+      success: RemoveHubbleMeasurementResult.success(result)
+    });
 });
 
 router.get("/measurements/:studentID", async (req, res) => {


### PR DESCRIPTION
This PR adds the `/hubbles_law/measurement` endpoint which allows us to remove a measurement from the database. This endpoint accepts a DELETE request that expects the following data:
* `student_id: number`
* one of the following:
  - `galaxy_id: number`
  - `galaxy_name: string`