### PR TITLE
Add mark-tileload-bad endpoint

### DIFF
--- a/sql/create_galaxy_table.sql
+++ b/sql/create_galaxy_table.sql
@@ -10,6 +10,7 @@ CREATE TABLE Galaxies(
     is_bad tinyint(2) NOT NULL DEFAULT 0,
     spec_marked_bad int NOT NULL DEFAULT 0,
     spec_is_bad tinyint(2) NOT NULL DEFAULT 0,
+    tileload_marked_bad int NOT NULL DEFAULT 0,
 
     PRIMARY KEY(id)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -110,3 +110,7 @@ export async function markGalaxyBad(galaxy: Galaxy): Promise<void> {
 export async function markGalaxySpectrumBad(galaxy: Galaxy): Promise<void> {
   galaxy.update({ spec_marked_bad: galaxy.spec_marked_bad + 1 });
 }
+
+export async function markGalaxyTileloadBad(galaxy: Galaxy): Promise<void> {
+  galaxy.update({ tileload_marked_bad: galaxy.tileload_marked_bad + 1 });
+}

--- a/src/stories/hubbles_law/models/galaxy.ts
+++ b/src/stories/hubbles_law/models/galaxy.ts
@@ -12,6 +12,7 @@ export class Galaxy extends Model<InferAttributes<Galaxy>, InferCreationAttribut
   declare is_bad: CreationOptional<number>;
   declare spec_marked_bad: CreationOptional<number>;
   declare spec_is_bad: CreationOptional<number>;
+  declare tileload_marked_bad: CreationOptional<number>;
 }
 
 export function initializeGalaxyModel(sequelize: Sequelize) {
@@ -62,6 +63,10 @@ export function initializeGalaxyModel(sequelize: Sequelize) {
     },
     spec_is_bad: {
       type: DataTypes.TINYINT,
+      allowNull: false
+    },
+    tileload_marked_bad: {
+      type: DataTypes.INTEGER,
       allowNull: false
     }
   }, {

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -10,6 +10,7 @@ import {
   getAllGalaxies,
   markGalaxyBad,
   markGalaxySpectrumBad,
+  markGalaxyTileloadBad,
   getHubbleMeasurement,
   submitHubbleMeasurement,
   getStudentHubbleMeasurements,
@@ -154,6 +155,10 @@ router.put("/mark-galaxy-bad", async (req, res) => {
 
 router.post("/mark-spectrum-bad", async (req, res) => {
   markBad(req, res, markGalaxySpectrumBad, "galaxy_spectrum_marked_bad");
+});
+
+router.post("/mark-tileload-bad", async (req, res) => {
+  markBad(req, res, markGalaxyTileloadBad, "galaxy_tileload_marked_bad");
 });
 
 export default router;


### PR DESCRIPTION
This PR creates a new endpoint for marking that a tile load for a galaxy was bad. While I don't think we'll really need to act on this, I would be curious to know if this ends up being a recurring problem for some galaxies in particular.