### PR TITLE
Add endpoints for the spectrum checking branch

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -110,3 +110,21 @@ export async function markGalaxyBad(galaxy: Galaxy): Promise<void> {
 export async function markGalaxySpectrumBad(galaxy: Galaxy): Promise<void> {
   galaxy.update({ spec_marked_bad: galaxy.spec_marked_bad + 1 });
 }
+
+/** These functions are specifically for the spectrum-checking branch */
+
+export async function setGalaxySpectrumStatus(galaxy: Galaxy, good: boolean): Promise<void> {
+  const goodInt = good ? 1 : 0;
+  const update = {
+    spec_is_good: goodInt,
+    spec_is_bad: 1 - goodInt,
+    spec_checked: galaxy.spec_checked + 1
+  };
+  await galaxy.update(update);
+}
+
+export async function getUncheckedSpectraGalaxies(): Promise<Galaxy[]> {
+  return Galaxy.findAll({
+    where: { spec_checked: 0 }
+  });
+}

--- a/src/stories/hubbles_law/models/galaxy.ts
+++ b/src/stories/hubbles_law/models/galaxy.ts
@@ -12,6 +12,8 @@ export class Galaxy extends Model<InferAttributes<Galaxy>, InferCreationAttribut
   declare is_bad: CreationOptional<number>;
   declare spec_marked_bad: CreationOptional<number>;
   declare spec_is_bad: CreationOptional<number>;
+  declare spec_is_good: CreationOptional<number>;
+  declare spec_checked: CreationOptional<number>;
 }
 
 export function initializeGalaxyModel(sequelize: Sequelize) {
@@ -62,6 +64,14 @@ export function initializeGalaxyModel(sequelize: Sequelize) {
     },
     spec_is_bad: {
       type: DataTypes.TINYINT,
+      allowNull: false
+    },
+    spec_is_good: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    spec_checked: {
+      type: DataTypes.INTEGER,
       allowNull: false
     }
   }, {


### PR DESCRIPTION
This PR adds endpoints that are specifically for the spectrum-checking branch. The endpoints are

* `GET /hubbles_law/unchecked-galaxies`: This endpoint gets galaxies that haven't been checked in that branch yet
* `POST /hubbles_law/set-spectrum-states`: This endpoint sets the galaxy spectrum status directly - that is, it sets `spec_is_bad` rather than `spec_marked_bad` (it also sets `spec_is_good`, but that doesn't have a marking equivalent)