### PR TITLE
Include galaxy data in Hubble measurement queries

### DIFF
--- a/src/stories/hubbles_law/associations.ts
+++ b/src/stories/hubbles_law/associations.ts
@@ -1,5 +1,5 @@
 import { Class, Student } from "../../models";
-import { HubbleMeasurement, SyncMergedHubbleClasses } from "./models";
+import { Galaxy, HubbleMeasurement, SyncMergedHubbleClasses } from "./models";
 import { AsyncMergedHubbleStudentClasses } from "./models/async_merged_student_classes";
 
 export function setUpHubbleAssociations() {
@@ -8,6 +8,12 @@ export function setUpHubbleAssociations() {
     as: "student",
     targetKey: "id",
     foreignKey: "student_id",
+  });
+
+  HubbleMeasurement.belongsTo(Galaxy, {
+    as: "galaxy",
+    targetKey: "id",
+    foreignKey: "galaxy_id"
   });
 
   AsyncMergedHubbleStudentClasses.belongsTo(Student, {

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -8,6 +8,8 @@ import { Class, Student } from "../../models";
 initializeModels(cosmicdsDB);
 setUpHubbleAssociations();
 
+const galaxyAttributes = ["ra", "decl", "z", "type", "name"];
+
 export async function submitHubbleMeasurement(data: {
   student_id: number,
   galaxy_id: number,
@@ -61,8 +63,14 @@ export async function getHubbleMeasurement(studentID: number, galaxyID: number):
       [Op.and]: [
         { student_id: studentID },
         { galaxy_id: galaxyID }
-      ]
-    }
+      ],
+    },
+    include: [{
+      model: Galaxy,
+      attributes: galaxyAttributes,
+      as: "galaxy",
+      required: true
+    }]
   }).catch(error => {
     console.log(error);
     return null;
@@ -70,16 +78,21 @@ export async function getHubbleMeasurement(studentID: number, galaxyID: number):
 }
 
 export async function getStudentHubbleMeasurements(studentID: number): Promise<HubbleMeasurement[] | null> {
-  const result = await HubbleMeasurement.findAll({
-  where: {
+  return HubbleMeasurement.findAll({
+    where: {
       student_id: studentID
-    }
+    },
+    include: [{
+      model: Galaxy,
+      attributes: galaxyAttributes,
+      as: "galaxy",
+      required: true
+    }]
   })
   .catch(error => {
     console.log(error);
     return null;
   });
-  return result;
 }
 
 async function getHubbleMeasurementsForClasses(classIDs: number[]): Promise<HubbleMeasurement[] | null> {
@@ -98,6 +111,12 @@ async function getHubbleMeasurementsForClasses(classIDs: number[]): Promise<Hubb
           }
         }
       }]
+    },
+    {
+      model: Galaxy,
+      attributes: galaxyAttributes,
+      as: "galaxy",
+      required: true
     }]
   });
 }


### PR DESCRIPTION
This PR modifies the endpoints that provide Hubble measurements to include the data for each galaxy in the response. This will be useful in the app for repopulating student data, and may simplify data fetching in our places as well.