### PR TITLE
Stage 3 data setup, part 3

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DB_PASSWORD=qeQn0nxb3ARJ^Q14

--- a/src/stories/hubbles_law/associations.ts
+++ b/src/stories/hubbles_law/associations.ts
@@ -1,6 +1,8 @@
 import { Class, Student } from "../../models";
 import { Galaxy, HubbleMeasurement, SyncMergedHubbleClasses } from "./models";
 import { AsyncMergedHubbleStudentClasses } from "./models/async_merged_student_classes";
+import { HubbleClassData } from "./models/hubble_class_data";
+import { HubbleStudentData } from "./models/hubble_student_data";
 
 export function setUpHubbleAssociations() {
 
@@ -14,6 +16,18 @@ export function setUpHubbleAssociations() {
     as: "galaxy",
     targetKey: "id",
     foreignKey: "galaxy_id"
+  });
+
+  HubbleStudentData.belongsTo(Student, {
+    as: "student",
+    targetKey: "id",
+    foreignKey: "student_id"
+  });
+
+  HubbleClassData.belongsTo(Class, {
+    as: "class",
+    targetKey: "id",
+    foreignKey: "class_id"
   });
 
   AsyncMergedHubbleStudentClasses.belongsTo(Student, {

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -107,6 +107,7 @@ async function getHubbleMeasurementsForClasses(classIDs: number[]): Promise<Hubb
       required: true,
       include: [{
         model: Class,
+        attributes: ["id"],
         where: {
           id: {
             [Op.in]: classIDs
@@ -132,6 +133,7 @@ async function getHubbleStudentDataForClasses(classIDs: number[]): Promise<Hubbl
       required: true,
       include: [{
         model: Class,
+        attributes: ["id"],
         where: {
           id: {
             [Op.in]: classIDs

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -4,6 +4,8 @@ import { cosmicdsDB, findClassById, findStudentById } from "../../database";
 import { RemoveHubbleMeasurementResult, SubmitHubbleMeasurementResult } from "./request_results";
 import { setUpHubbleAssociations } from "./associations";
 import { Class, Student } from "../../models";
+import { HubbleStudentData } from "./models/hubble_student_data";
+import { HubbleClassData } from "./models/hubble_class_data";
 
 initializeModels(cosmicdsDB);
 setUpHubbleAssociations();
@@ -162,6 +164,18 @@ export async function getStageThreeMeasurements(studentID: number, classID: numb
     data = await getHubbleMeasurementsForSyncClass(classID);
   }
   return data ?? [];
+}
+
+export async function getAllHubbleMeasurements(): Promise<HubbleMeasurement[]> {
+  return HubbleMeasurement.findAll();
+}
+
+export async function getAllHubbleStudentData(): Promise<HubbleStudentData[]> {
+  return HubbleStudentData.findAll();
+}
+
+export async function getAllHubbleClassData(): Promise<HubbleClassData[]> {
+  return HubbleClassData.findAll();
 }
 
 export async function removeHubbleMeasurement(studentID: number, galaxyID: number): Promise<RemoveHubbleMeasurementResult> {

--- a/src/stories/hubbles_law/models/hubble_class_data.ts
+++ b/src/stories/hubbles_law/models/hubble_class_data.ts
@@ -1,0 +1,44 @@
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+import { Class } from "../../../models";
+
+export class HubbleClassData extends Model<InferAttributes<HubbleClassData>, InferCreationAttributes<HubbleClassData>> {
+  declare class_id: number;
+  declare hubble_fit_value: number;
+  declare hubble_fit_unit: string;
+  declare age_value: number;
+  declare age_unit: string;
+}
+
+export function initializeHubbleClassDataModel(sequelize: Sequelize) {
+  HubbleClassData.init({
+    class_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Class,
+        key: "id"
+      }
+    },
+    hubble_fit_value: {
+      type: DataTypes.FLOAT,
+      allowNull: true,
+    },
+    hubble_fit_unit: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    age_value: {
+      type: DataTypes.FLOAT,
+      allowNull: true
+    },
+    age_unit: {
+      type: DataTypes.STRING,
+      allowNull: true
+    }
+  }, {
+    sequelize,
+    engine: "InnoDB",
+    freezeTableName: true
+  });
+}

--- a/src/stories/hubbles_law/models/hubble_student_data.ts
+++ b/src/stories/hubbles_law/models/hubble_student_data.ts
@@ -38,6 +38,7 @@ export function initializeHubbleStudentDataModel(sequelize: Sequelize) {
     }
   }, {
     sequelize,
-    engine: "InnoDB"
+    engine: "InnoDB",
+    freezeTableName: true
   });
 }

--- a/src/stories/hubbles_law/models/hubble_student_data.ts
+++ b/src/stories/hubbles_law/models/hubble_student_data.ts
@@ -1,0 +1,43 @@
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+import { Student } from "../../../models";
+
+export class HubbleStudentData extends Model<InferAttributes<HubbleStudentData>, InferCreationAttributes<HubbleStudentData>> {
+  declare student_id: number;
+  declare hubble_fit_value: number;
+  declare hubble_fit_unit: string;
+  declare age_value: number;
+  declare age_unit: string;
+}
+
+export function initializeHubbleStudentDataModel(sequelize: Sequelize) {
+  HubbleStudentData.init({
+    student_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Student,
+        key: "id"
+      }
+    },
+    hubble_fit_value: {
+      type: DataTypes.FLOAT,
+      allowNull: true,
+    },
+    hubble_fit_unit: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    age_value: {
+      type: DataTypes.FLOAT,
+      allowNull: true
+    },
+    age_unit: {
+      type: DataTypes.STRING,
+      allowNull: true
+    }
+  }, {
+    sequelize,
+    engine: "InnoDB"
+  });
+}

--- a/src/stories/hubbles_law/models/index.ts
+++ b/src/stories/hubbles_law/models/index.ts
@@ -3,6 +3,8 @@ import { HubbleMeasurement, initializeHubbleMeasurementModel } from "./hubble_me
 import { AsyncMergedHubbleStudentClasses, initializeAsyncMergedHubbleStudentClassesModel } from "./async_merged_student_classes";
 import { SyncMergedHubbleClasses, initializeSyncMergedHubbleClassesModel } from "./sync_merged_classes";
 import { Sequelize } from "sequelize/types";
+import { initializeHubbleStudentDataModel } from "./hubble_student_data";
+import { initializeHubbleClassDataModel } from "./hubble_class_data";
 
 export {
   Galaxy,
@@ -16,4 +18,6 @@ export function initializeModels(db: Sequelize) {
   initializeHubbleMeasurementModel(db);
   initializeAsyncMergedHubbleStudentClassesModel(db);
   initializeSyncMergedHubbleClassesModel(db);
+  initializeHubbleStudentDataModel(db);
+  initializeHubbleClassDataModel(db);
 }

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -126,8 +126,11 @@ router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
   const params = req.params;
   const studentID = parseInt(params.studentID);
   const classID = parseInt(params.classID);
-  const measurements = await getStageThreeMeasurements(studentID, classID);
-  const studentData = await getStageThreeStudentData(studentID, classID);
+  const [measurements, studentData] =
+    await Promise.all([
+      getStageThreeMeasurements(studentID, classID),
+      getStageThreeStudentData(studentID, classID)
+    ]);
   const data = {
     measurements,
     studentData
@@ -138,8 +141,11 @@ router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
 router.get("/stage-3-data/:studentID", async (req, res) => {
   const params = req.params;
   const studentID = parseInt(params.studentID);
-  const measurements = await getStageThreeMeasurements(studentID, null);
-  const studentData = await getStageThreeStudentData(studentID, null);
+  const [measurements, studentData] =
+    await Promise.all([
+      getStageThreeMeasurements(studentID, null),
+      getStageThreeStudentData(studentID, null)
+    ]);
   const data = {
     measurements,
     studentData
@@ -148,9 +154,12 @@ router.get("/stage-3-data/:studentID", async (req, res) => {
 });
 
 router.get("/all-data", async (_req, res) => {
-  const measurements = await getAllHubbleMeasurements();
-  const studentData = await getAllHubbleStudentData();
-  const classData = await getAllHubbleClassData();
+  const [measurements, studentData, classData] =
+    await Promise.all([
+      getAllHubbleMeasurements(),
+      getAllHubbleStudentData(),
+      getAllHubbleClassData()
+    ]);
   res.json({
     measurements,
     studentData,

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -20,7 +20,8 @@ import {
   getStageThreeMeasurements,
   getAllHubbleMeasurements,
   getAllHubbleStudentData,
-  getAllHubbleClassData
+  getAllHubbleClassData,
+  getStageThreeStudentData
 } from "./database";
 
 import { 
@@ -126,8 +127,10 @@ router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
   const studentID = parseInt(params.studentID);
   const classID = parseInt(params.classID);
   const measurements = await getStageThreeMeasurements(studentID, classID);
+  const studentData = await getStageThreeStudentData(studentID, classID);
   const data = {
-    measurements: measurements
+    measurements,
+    studentData
   };
   res.json(data);
 });
@@ -136,8 +139,10 @@ router.get("/stage-3-data/:studentID", async (req, res) => {
   const params = req.params;
   const studentID = parseInt(params.studentID);
   const measurements = await getStageThreeMeasurements(studentID, null);
+  const studentData = await getStageThreeStudentData(studentID, null);
   const data = {
-    measurements: measurements
+    measurements,
+    studentData
   };
   res.json(data);
 });

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -17,7 +17,10 @@ import {
   removeHubbleMeasurement,
   setGalaxySpectrumStatus,
   getUncheckedSpectraGalaxies,
-  getStageThreeMeasurements
+  getStageThreeMeasurements,
+  getAllHubbleMeasurements,
+  getAllHubbleStudentData,
+  getAllHubbleClassData
 } from "./database";
 
 import { 
@@ -137,6 +140,17 @@ router.get("/stage-3-data/:studentID", async (req, res) => {
     measurements: measurements
   };
   res.json(data);
+});
+
+router.get("/all-data", async (_req, res) => {
+  const measurements = await getAllHubbleMeasurements();
+  const studentData = await getAllHubbleStudentData();
+  const classData = await getAllHubbleClassData();
+  res.json({
+    measurements,
+    studentData,
+    classData
+  });
 });
 
 router.get("/galaxies", async (_req, res) => {


### PR DESCRIPTION
This PR sets up the `HubbleStudentData` and `HubbleClassData` tables and models for getting aggregate Hubble values and ages for students and classes, as well as adding them to the `/stage-3-data` responses. Additionally, an `/all-data` endpoint is added for getting all of the summary data.