### PR TITLE
Add galaxy type information to `/all-data`

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -218,7 +218,13 @@ export async function getStageThreeStudentData(studentID: number, classID: numbe
 }
 
 export async function getAllHubbleMeasurements(): Promise<HubbleMeasurement[]> {
-  return HubbleMeasurement.findAll();
+  return HubbleMeasurement.findAll({
+    include: [{
+      model: Galaxy,
+      as: "galaxy",
+      attributes: ["id", "type"]
+    }]
+  });
 }
 
 export async function getAllHubbleStudentData(): Promise<HubbleStudentData[]> {


### PR DESCRIPTION
This PR adds galaxy type information to the data return from the `/all-data` endpoint. This is useful for creating the morphology subsets in the CosmicDS app.