### PR TITLE
Only grab data from seed or real students

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -477,6 +477,6 @@ export async function newDummyStudent(seed = false, teamMember: string | null = 
     gender: null,
     seed: seed ? 1 : 0,
     team_member: teamMember,
-    dummy: false
+    dummy: true
   });
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -476,6 +476,7 @@ export async function newDummyStudent(seed = false, teamMember: string | null = 
     age: null,
     gender: null,
     seed: seed ? 1 : 0,
-    team_member: teamMember
+    team_member: teamMember,
+    dummy: false
   });
 }

--- a/src/models/student.ts
+++ b/src/models/student.ts
@@ -20,6 +20,7 @@ export class Student extends Model<InferAttributes<Student>, InferCreationAttrib
   declare last_visit_ip: CreationOptional<string | null>;
   declare seed: CreationOptional<number>;
   declare team_member: CreationOptional<string | null>;
+  declare dummy: CreationOptional<boolean>;
 }
 
 export function initializeStudentModel(sequelize: Sequelize) {
@@ -96,6 +97,11 @@ export function initializeStudentModel(sequelize: Sequelize) {
     },
     team_member: {
       type: DataTypes.STRING
+    },
+    dummy: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     }
   }, {
     sequelize,

--- a/src/sql/create_student_table.sql
+++ b/src/sql/create_student_table.sql
@@ -16,7 +16,8 @@ CREATE TABLE Students (
     last_visit datetime NOT NULL,
     last_visit_ip varchar(50) COLLATE utf8_unicode_ci,
     seed tinyint(2) NOT NULL DEFAULT 0,
-    team_member varchar(30)
+    team_member varchar(30),
+    dummy tinyint(1) NOT NULL DEFAULT 0,
 
     PRIMARY KEY(id),
     INDEX(username),

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -223,12 +223,32 @@ export async function getAllHubbleMeasurements(): Promise<HubbleMeasurement[]> {
       model: Galaxy,
       as: "galaxy",
       attributes: ["id", "type"]
+    }, {
+      model: Student,
+      as: "student",
+      attributes: ["seed", "dummy"],
+      where: {
+        [Op.or]: [
+          { seed: 1 }, { dummy: 0 }
+        ]
+      }
     }]
   });
 }
 
 export async function getAllHubbleStudentData(): Promise<HubbleStudentData[]> {
-  return HubbleStudentData.findAll();
+  return HubbleStudentData.findAll({
+    include: [{
+      model: Student,
+      as: "student",
+      attributes: ["seed", "dummy"],
+      where: {
+        [Op.or]: [
+          { seed: 1 }, { dummy: 0 }
+        ]
+      }
+    }]
+  });
 }
 
 export async function getAllHubbleClassData(): Promise<HubbleClassData[]> {


### PR DESCRIPTION
This PR uses a newly-added `dummy` flag on every dummy student (seed or otherwise) to allow us to grab only seed or real student data from the `/all-data` endpoint.