### PR TITLE
Simplify `/stage-3-data`

### DIFF
--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -126,31 +126,15 @@ router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
   const params = req.params;
   const studentID = parseInt(params.studentID);
   const classID = parseInt(params.classID);
-  const [measurements, studentData] =
-    await Promise.all([
-      getStageThreeMeasurements(studentID, classID),
-      getStageThreeStudentData(studentID, classID)
-    ]);
-  const data = {
-    measurements,
-    studentData
-  };
-  res.json(data);
+  const measurements = await getStageThreeMeasurements(studentID, classID);
+  res.json(measurements);
 });
 
 router.get("/stage-3-data/:studentID", async (req, res) => {
   const params = req.params;
   const studentID = parseInt(params.studentID);
-  const [measurements, studentData] =
-    await Promise.all([
-      getStageThreeMeasurements(studentID, null),
-      getStageThreeStudentData(studentID, null)
-    ]);
-  const data = {
-    measurements,
-    studentData
-  };
-  res.json(data);
+  const measurements = await getStageThreeMeasurements(studentID, null);
+  res.json(measurements);
 });
 
 router.get("/all-data", async (_req, res) => {


### PR DESCRIPTION
Since we're going to generate the summaries for the current class on the fly at runtime, there's no need for anything aside from the appropriate measurements in `/stage-3-data`.