### PR TITLE
Set default values separately when fetching stage three data

### DIFF
--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -126,8 +126,10 @@ router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
   const params = req.params;
   let studentID = parseInt(params.studentID);
   let classID = parseInt(params.classID);
-  if (studentID === 0 && classID === 0) {
+  if (studentID === 0) {
     studentID = 8;
+  }
+  if (classID === 0) {
     classID = 100;
   }
   const measurements = await getStageThreeMeasurements(studentID, classID);


### PR DESCRIPTION
This PR sets the default values for class and student IDs separately when getting stage three data. This will be useful for the state testing branch, where we want to specify a student ID, but may not want to put that student into a class.