### PR TITLE
Add galaxy endpoint for data generation branch

### DIFF
--- a/src/stories/hubbles_law/associations.ts
+++ b/src/stories/hubbles_law/associations.ts
@@ -12,6 +12,9 @@ export function setUpHubbleAssociations() {
     foreignKey: "student_id",
   });
 
+  Galaxy.hasMany(HubbleMeasurement, {
+    foreignKey: "galaxy_id"
+  });
   HubbleMeasurement.belongsTo(Galaxy, {
     as: "galaxy",
     targetKey: "id",

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -1,4 +1,4 @@
-import { Op } from "sequelize";
+import { Op, Sequelize } from "sequelize";
 import { AsyncMergedHubbleStudentClasses, Galaxy, HubbleMeasurement, initializeModels, SyncMergedHubbleClasses } from "./models";
 import { cosmicdsDB, findClassById, findStudentById } from "../../database";
 import { RemoveHubbleMeasurementResult, SubmitHubbleMeasurementResult } from "./request_results";
@@ -322,5 +322,45 @@ export async function setGalaxySpectrumStatus(galaxy: Galaxy, good: boolean): Pr
 export async function getUncheckedSpectraGalaxies(): Promise<Galaxy[]> {
   return Galaxy.findAll({
     where: { spec_checked: 0 }
+  });
+}
+
+/** These functions are specifically for the data generation branch */
+
+/** For the data generation branch, we want to preferentially choose galaxies with 
+ * fewer measurements. So this function will sort the galaxies by the number of measurements 
+ * from seed students. The data generation branch will then feed this data sequentially
+ * to the team members using it.
+ * 
+ * The SQL that we're looking to generate here is
+ * SELECT Galaxies.id FROM Galaxies
+ * INNER JOIN HubbleMeasurements ON Galaxies.id = HubbleMeasurements.galaxy_id
+ * INNER JOIN Students on Students.id = HubbleMeasurements.student_id
+ * WHERE (Students.seed = 1 OR Students.dummy = 0)
+ * GROUP BY Galaxies.id
+ * ORDER BY COUNT(Galaxies.id);
+ */
+export async function getGalaxiesForDataGeneration(): Promise<Galaxy[]> {
+  return Galaxy.findAll({
+    include: [
+      {
+        model: HubbleMeasurement,
+        attributes: ["student_id", "galaxy_id"],
+        required: true,
+        include: [{
+          model: Student,
+          as: "student",
+          attributes: ["id"],
+          required: true,
+          where: {
+            [Op.or]: [
+              { seed: 1 }, { dummy: 0 }
+            ]
+          }
+        }]
+      }
+    ],
+    group: ['Galaxy.id'],
+    order: Sequelize.fn('count', Sequelize.col('Galaxy.id'))
   });
 }

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -360,7 +360,7 @@ export async function getGalaxiesForDataGeneration(): Promise<Galaxy[]> {
         }]
       }
     ],
-    group: ['Galaxy.id'],
-    order: Sequelize.fn('count', Sequelize.col('Galaxy.id'))
+    group: ["Galaxy.id"],
+    order: Sequelize.fn("count", Sequelize.col("Galaxy.id"))
   });
 }

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -21,7 +21,8 @@ import {
   getAllHubbleMeasurements,
   getAllHubbleStudentData,
   getAllHubbleClassData,
-  getStageThreeStudentData
+  getStageThreeStudentData,
+  getGalaxiesForDataGeneration
 } from "./database";
 
 import { 
@@ -255,6 +256,12 @@ router.post("/set-spectrum-status", async (req, res) => {
     marked_bad: !good,
     galaxy: name
   });
+});
+
+/** These endpoints are specifically for the data generation branch */
+router.get("/data-generation-galaxies", async (_req, res) => {
+  const galaxies = await getGalaxiesForDataGeneration().catch(console.log);
+  res.json(galaxies);
 });
 
 export default router;


### PR DESCRIPTION
This PR adds a `/hubbles_law/data-generation-galaxies` endpoint. A `GET` request to this endpoint will return the list of galaxies, sorted by the number of seed measurements for that galaxy that exist in the database (fewer measurements means earlier in the list). This endpoint is intended for the student data generation branch, so that we can generate more measurements with galaxies that have fewer.