### PR TITLE
Update ESLint and fix warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,13 @@
     ],
     "rules": {
         "@typescript-eslint/no-namespace": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "warn", {
+            "args": "all",
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_"
+          }
+        ],
         "linebreak-style": [
             "error",
             "unix"

--- a/src/models/dummy_class.ts
+++ b/src/models/dummy_class.ts
@@ -1,4 +1,4 @@
-import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes } from "sequelize";
 import { Class } from "./class";
 import { Story } from "./story";
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,7 +44,7 @@ export const app = express();
 
 // TODO: Clean up these type definitions
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
 export type GenericRequest = Request<{}, any, any, ParsedQs, Record<string, any>>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type GenericResponse = Response<any, Record<string, any>, number>;
@@ -141,7 +141,7 @@ app.get("/", (_req, res) => {
   res.json({ message: "Welcome to the CosmicDS server." });
 });
 
-function sendUserIdCookie(userId: number, res: ExpressResponse): void {
+function _sendUserIdCookie(userId: number, res: ExpressResponse): void {
   const expirationTime = 24 * 60 * 60; // one day
   console.log("Sending cookie");
   res.cookie("userId", userId,
@@ -152,7 +152,7 @@ function sendUserIdCookie(userId: number, res: ExpressResponse): void {
     });
 }
 
-function sendLoginCookie(userId: number, res: ExpressResponse): void {
+function _sendLoginCookie(userId: number, res: ExpressResponse): void {
   const expirationTime = 24 * 60 * 60; // one day
   const token = jwt.sign({
     data: {

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -205,7 +205,7 @@ async function getHubbleStudentDataForSyncClass(classID: number): Promise<Hubble
   return getHubbleStudentDataForClasses(classIDs);
 }
 
-export async function getStageThreeStudentData(studentID: number, classID: number | null): Promise<HubbleStudentData[]> {
+export async function _getStageThreeStudentData(studentID: number, classID: number | null): Promise<HubbleStudentData[]> {
   const cls = classID !== null ? await findClassById(classID) : null;
   const asyncClass = cls?.asynchronous ?? true;
   let data: HubbleStudentData[] | null;
@@ -333,7 +333,7 @@ export async function getUncheckedSpectraGalaxies(): Promise<Galaxy[]> {
  * to the team members using it.
  * 
  * The SQL that we're looking to generate here is
- * SELECT Galaxies.id FROM Galaxies
+ * SELECT * FROM Galaxies
  * INNER JOIN HubbleMeasurements ON Galaxies.id = HubbleMeasurements.galaxy_id
  * INNER JOIN Students on Students.id = HubbleMeasurements.student_id
  * WHERE (Students.seed = 1 OR Students.dummy = 0)

--- a/src/stories/hubbles_law/models/hubble_class_data.ts
+++ b/src/stories/hubbles_law/models/hubble_class_data.ts
@@ -1,4 +1,4 @@
-import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes } from "sequelize";
 import { Class } from "../../../models";
 
 export class HubbleClassData extends Model<InferAttributes<HubbleClassData>, InferCreationAttributes<HubbleClassData>> {

--- a/src/stories/hubbles_law/models/hubble_student_data.ts
+++ b/src/stories/hubbles_law/models/hubble_student_data.ts
@@ -1,4 +1,4 @@
-import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes } from "sequelize";
 import { Student } from "../../../models";
 
 export class HubbleStudentData extends Model<InferAttributes<HubbleStudentData>, InferCreationAttributes<HubbleStudentData>> {

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -21,7 +21,6 @@ import {
   getAllHubbleMeasurements,
   getAllHubbleStudentData,
   getAllHubbleClassData,
-  getStageThreeStudentData,
   getGalaxiesForDataGeneration
 } from "./database";
 


### PR DESCRIPTION
This PR updates our ESLint TypeScript rules to include a pattern for unused variables (they should start with an underscore). This also includes a few bits of code cleanup to remove linting warnings.