### PR TITLE
Add endpoint for new set of galaxies

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -325,6 +325,17 @@ export async function getUncheckedSpectraGalaxies(): Promise<Galaxy[]> {
   });
 }
 
+export async function getNewGalaxies(): Promise<Galaxy[]> {
+  return Galaxy.findAll({
+    where: {
+      [Op.and]: [
+        { id: { [Op.gt]: 1387 } },
+        { id: { [Op.lte]: 1788 } },
+      ]
+    }
+  });
+}
+
 /** These functions are specifically for the data generation branch */
 
 /** For the data generation branch, we want to preferentially choose galaxies with 

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -21,7 +21,8 @@ import {
   getAllHubbleMeasurements,
   getAllHubbleStudentData,
   getAllHubbleClassData,
-  getGalaxiesForDataGeneration
+  getGalaxiesForDataGeneration,
+  getNewGalaxies
 } from "./database";
 
 import { 
@@ -255,6 +256,11 @@ router.post("/set-spectrum-status", async (req, res) => {
     marked_bad: !good,
     galaxy: name
   });
+});
+
+router.get("/new-galaxies", async (_req, res) => {
+  const galaxies = await getNewGalaxies();
+  res.json(galaxies);
 });
 
 /** These endpoints are specifically for the data generation branch */


### PR DESCRIPTION
This PR adds a new `/hubbles_law/new-galaxies` endpoint which returns only the subset of newly-added galaxies. This will be useful for tile and spectrum testing of these galaxies.