### PR TITLE
Remove bad galaxies from new-galaxies endpoint

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -329,6 +329,7 @@ export async function getNewGalaxies(): Promise<Galaxy[]> {
   return Galaxy.findAll({
     where: {
       [Op.and]: [
+        { is_bad: 0 },
         { id: { [Op.gt]: 1387 } },
         { id: { [Op.lte]: 1788 } },
       ]


### PR DESCRIPTION
This PR adds the same `is_bad: 0` check that we use on the regular `hubbles_law/galaxies` endpoint to the `hubbles_law/new-galaxies` endpoint as well.