### PR TITLE
Remove unnecessary fields from data generation galaxies

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -357,12 +357,12 @@ export async function getGalaxiesForDataGeneration(): Promise<Galaxy[]> {
     include: [
       {
         model: HubbleMeasurement,
-        attributes: ["student_id", "galaxy_id"],
+        attributes: [],
         required: true,
         include: [{
           model: Student,
           as: "student",
-          attributes: ["id"],
+          attributes: [],
           required: true,
           where: {
             [Op.or]: [


### PR DESCRIPTION
The `/hubbles_law/data-generation-galaxies` endpoint is working fine, but returns more info than it needs to. This PR pares down the query response to only include the galaxy data, rather than also including stuff it picked up during table joins.