### PR TITLE
Add Hubble's Law endpoint for getting spectrum data

### DIFF
--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -213,6 +213,10 @@ router.post("/mark-spectrum-bad", async (req, res) => {
   markBad(req, res, markGalaxySpectrumBad, "galaxy_spectrum_marked_bad");
 });
 
+router.get("/spectra/:type/:name", async (req, res) => {
+  res.redirect(`https://cosmicds.s3.us-east-1.amazonaws.com/spectra/${req.params.type}/${req.params.name}`);
+});
+
 
 /** These endpoints are specifically for the spectrum-checking branch */
 


### PR DESCRIPTION
This PR adds a `/hubbles_law/spectra/:type/:name` endpoint that we can GET to retrieve the FITS data for the given spectrum. This endpoint just redirects to the appropriate object in our AWS S3 bucket, but this way, if we need to do any additional handling of parameters in the future, we can do it here.