### PR TITLE
Allow specifying galaxy types in query

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -265,6 +265,16 @@ export async function removeHubbleMeasurement(studentID: number, galaxyID: numbe
   return count > 0 ? RemoveHubbleMeasurementResult.MeasurementDeleted : RemoveHubbleMeasurementResult.NoSuchMeasurement;
 }
 
+export async function getGalaxiesForTypes(types: string[]): Promise<Galaxy[]> {
+  return Galaxy.findAll({
+    where: {
+      is_bad: 0,
+      spec_is_bad: 0,
+      type: { [Op.in]: types }
+    }
+  });
+}
+
 export async function getAllGalaxies(): Promise<Galaxy[]> {
   return Galaxy.findAll({
     where: {

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -22,7 +22,8 @@ import {
   getAllHubbleStudentData,
   getAllHubbleClassData,
   getGalaxiesForDataGeneration,
-  getNewGalaxies
+  getNewGalaxies,
+  getGalaxiesForTypes
 } from "./database";
 
 import { 
@@ -30,7 +31,7 @@ import {
   SubmitHubbleMeasurementResult
 } from "./request_results";
 
-import { Router } from "express";
+import { request, Router } from "express";
 
 const router = Router();
 
@@ -166,9 +167,21 @@ router.get("/all-data", async (_req, res) => {
   });
 });
 
-router.get("/galaxies", async (_req, res) => {
-  const response = await getAllGalaxies();
-  res.json(response);
+router.get("/galaxies", async (req, res) => {
+  const types = req.query?.types ?? undefined;
+  let galaxies: Galaxy[];
+  if (types === undefined) {
+    galaxies = await getAllGalaxies();
+  } else {
+    let galaxyTypes: string[];
+    if (Array.isArray(types)) {
+      galaxyTypes = types as string[];
+    } else {
+      galaxyTypes = (types as string).split(",");
+    }
+    galaxies = await getGalaxiesForTypes(galaxyTypes);
+  }
+  res.json(galaxies);
 });
 
 async function markBad(req: GenericRequest, res: GenericResponse, marker: (galaxy: Galaxy) => Promise<void>, markedStatus: string) {


### PR DESCRIPTION
This PR adds functionality for specifying which galaxy types are desired to the `/hubbles_law/galaxies` endpoint. The types should be given in the form they are stored in the database (Sp, E, Ir). An example query, to get only spiral galaxies, would have the form `/hubbles_law/galaxies?types=Sp`.

If no query types parameter is provided, all galaxies are returned, which matches the current behavior.