### PR TITLE
Have the data generation endpoint only return spiral galaxies

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -366,11 +366,12 @@ export async function getNewGalaxies(): Promise<Galaxy[]> {
  * GROUP BY Galaxies.id
  * ORDER BY COUNT(Galaxies.id), Galaxy.id DESC
  */
-export async function getGalaxiesForDataGeneration(): Promise<Galaxy[]> {
+export async function getGalaxiesForDataGeneration(types=["Sp"]): Promise<Galaxy[]> {
   const measurements = await Galaxy.findAll({
     where: {
       is_bad: 0,
-      spec_is_bad: 0
+      spec_is_bad: 0,
+      type: { [Op.in]: types }
     },
     include: [
       {
@@ -398,6 +399,7 @@ export async function getGalaxiesForDataGeneration(): Promise<Galaxy[]> {
     where: {
       is_bad: 0,
       spec_is_bad: 0,
+      type: { [Op.in]: types },
       id: { [Op.notIn]: measurementIDs }
     },
     order: [["id", "DESC"]]


### PR DESCRIPTION
This PR changes the galaxy endpoint for the data generation branch to only return spirals (to match changes to the main branch).