### PR TITLE
Only grab class summaries for classes with 15 students

### DIFF
--- a/src/stories/hubbles_law/associations.ts
+++ b/src/stories/hubbles_law/associations.ts
@@ -1,4 +1,4 @@
-import { Class, Student } from "../../models";
+import { Class, Student, StudentsClasses } from "../../models";
 import { Galaxy, HubbleMeasurement, SyncMergedHubbleClasses } from "./models";
 import { AsyncMergedHubbleStudentClasses } from "./models/async_merged_student_classes";
 import { HubbleClassData } from "./models/hubble_class_data";
@@ -30,6 +30,12 @@ export function setUpHubbleAssociations() {
   HubbleClassData.belongsTo(Class, {
     as: "class",
     targetKey: "id",
+    foreignKey: "class_id"
+  });
+
+  HubbleClassData.belongsTo(StudentsClasses, {
+    as: "class_data",
+    targetKey: "class_id",
     foreignKey: "class_id"
   });
 

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -259,7 +259,7 @@ export async function getAllHubbleClassData(): Promise<HubbleClassData[]> {
       attributes: []
     }],
     group: ["HubbleClassData.class_id"],
-    having: Sequelize.where(Sequelize.fn('count', Sequelize.col('HubbleClassData.class_id')), { [Op.gte]: 15 })
+    having: Sequelize.where(Sequelize.fn("count", Sequelize.col("HubbleClassData.class_id")), { [Op.gte]: 15 })
   });
 }
 

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -3,7 +3,7 @@ import { AsyncMergedHubbleStudentClasses, Galaxy, HubbleMeasurement, initializeM
 import { cosmicdsDB, findClassById, findStudentById } from "../../database";
 import { RemoveHubbleMeasurementResult, SubmitHubbleMeasurementResult } from "./request_results";
 import { setUpHubbleAssociations } from "./associations";
-import { Class, Student } from "../../models";
+import { Class, Student, StudentsClasses } from "../../models";
 import { HubbleStudentData } from "./models/hubble_student_data";
 import { HubbleClassData } from "./models/hubble_class_data";
 
@@ -252,7 +252,15 @@ export async function getAllHubbleStudentData(): Promise<HubbleStudentData[]> {
 }
 
 export async function getAllHubbleClassData(): Promise<HubbleClassData[]> {
-  return HubbleClassData.findAll();
+  return HubbleClassData.findAll({
+    include: [{
+      model: StudentsClasses,
+      as: "class_data",
+      attributes: []
+    }],
+    group: ["HubbleClassData.class_id"],
+    having: Sequelize.where(Sequelize.fn('count', Sequelize.col('HubbleClassData.class_id')), { [Op.gte]: 15 })
+  });
 }
 
 export async function removeHubbleMeasurement(studentID: number, galaxyID: number): Promise<RemoveHubbleMeasurementResult> {


### PR DESCRIPTION
This PR modifies the `/all-data` endpoint to only fetch class summary data for classes that have at least 15 students.