### PR TITLE
Get class for student/story pair

### DIFF
--- a/src/associations.ts
+++ b/src/associations.ts
@@ -64,4 +64,22 @@ export function setUpAssociations() {
     foreignKey: "story_name"
   });
 
+  Class.hasMany(ClassStories, {
+    foreignKey: "class_id"
+  });
+  ClassStories.belongsTo(Class, {
+    as: "class",
+    targetKey: "id",
+    foreignKey: "class_id"
+  });
+
+  Class.hasMany(StudentsClasses, {
+    foreignKey: "class_id"
+  });
+  StudentsClasses.belongsTo(Class, {
+    as: "class",
+    targetKey: "id",
+    foreignKey: "class_id"
+  });
+
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -465,7 +465,7 @@ export async function getRosterInfo(classID: number, useDisplayNames = true): Pr
   }, {});
 }
 
-/** For testing purposes */
+/** These functions are for testing purposes only */
 export async function newDummyClassForStory(storyName: string): Promise<{cls: Class, dummy: DummyClass}> {
   const ct = await Class.count({
     where: {
@@ -545,4 +545,27 @@ export async function newDummyStudent(seed = false,
   }
 
   return student;
+}
+
+export async function classForStudentStory(studentID: number, storyName: string): Promise<Class | null> {
+  return Class.findOne({
+    include: [
+      {
+        model: ClassStories,
+        required: true,
+        attributes: [],
+        where: {
+          story_name: storyName
+        }
+      },
+      {
+        model: StudentsClasses,
+        required: true,
+        attributes: [],
+        where: {
+          student_id: studentID
+        }
+      }
+    ]
+  });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import {
   getRosterInfoForStory,
   findStudentById,
   findStudentByUsername,
+  classForStudentStory,
   
 } from "./database";
 
@@ -449,4 +450,16 @@ app.post("/new-dummy-student", async (req, res) => {
   res.json({
     student: student
   });
+});
+
+app.get("/class-for-student-story/:studentID/:storyName", async (req, res) => {
+  const studentID = parseInt(req.params.studentID);
+  const storyName = req.params.storyName;
+  const cls = isNaN(studentID) ? null : await classForStudentStory(studentID, storyName);
+  res.json({
+    class: cls
+  });
+  if (cls == null) {
+    res.statusCode = 404;
+  }
 });


### PR DESCRIPTION
This PR adds functionality for getting the class information from a student/story pair. This logic is good enough for now, but it relies on a student only being in one class that's doing a particular data story. I'll update this accordingly once we make a final decision on how to handle those types of situations.