### PR TITLE
Sample galaxy data

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -1,5 +1,5 @@
 import { Op, Sequelize } from "sequelize";
-import { AsyncMergedHubbleStudentClasses, Galaxy, HubbleMeasurement, initializeModels, SyncMergedHubbleClasses } from "./models";
+import { AsyncMergedHubbleStudentClasses, Galaxy, HubbleMeasurement, SampleHubbleMeasurement, initializeModels, SyncMergedHubbleClasses } from "./models";
 import { cosmicdsDB, findClassById, findStudentById } from "../../database";
 import { RemoveHubbleMeasurementResult, SubmitHubbleMeasurementResult } from "./request_results";
 import { setUpHubbleAssociations } from "./associations";
@@ -59,6 +59,53 @@ export async function submitHubbleMeasurement(data: {
   }
 }
 
+export async function submitSampleHubbleMeasurement(data: {
+  student_id: number,
+  galaxy_id: number,
+  rest_wave_value: number | null,
+  rest_wave_unit: string | null,
+  obs_wave_value: number | null,
+  obs_wave_unit: string | null,
+  velocity_value: number | null,
+  velocity_unit: string | null,
+  ang_size_value: number | null,
+  ang_size_unit: string | null,
+  est_dist_value: number | null,
+  est_dist_unit: string | null
+}): Promise<SubmitHubbleMeasurementResult> {
+
+  const student = await findStudentById(data.student_id);
+  if (student === null) {
+    return SubmitHubbleMeasurementResult.NoSuchStudent;
+  }
+
+  const measurement = await SampleHubbleMeasurement.findOne({
+    where: {
+      [Op.and]: [
+        { student_id: data.student_id },
+        { galaxy_id: data.galaxy_id }
+      ]
+    }
+  })
+  .catch(console.log);
+
+  if (measurement) {
+    measurement.update(data, {
+      where: {
+        [Op.and]: [
+          { student_id: measurement.student_id },
+          { galaxy_id: measurement.galaxy_id }
+        ]
+      }
+    })
+    .catch(console.log);
+    return SubmitHubbleMeasurementResult.MeasurementUpdated;
+  } else {
+    SampleHubbleMeasurement.create(data).catch(console.log);
+    return SubmitHubbleMeasurementResult.MeasurementCreated;
+  }
+}
+
 export async function getHubbleMeasurement(studentID: number, galaxyID: number): Promise<HubbleMeasurement | null> {
   return HubbleMeasurement.findOne({
     where: {
@@ -77,6 +124,25 @@ export async function getHubbleMeasurement(studentID: number, galaxyID: number):
     console.log(error);
     return null;
   });
+}
+
+export async function getSampleHubbleMeasurement(studentID: number): Promise<SampleHubbleMeasurement | null> {
+  return SampleHubbleMeasurement.findOne({
+    where: { student_id: studentID },
+    include: [{
+      model: Galaxy,
+      attributes: galaxyAttributes,
+      as: "galaxy",
+      required: true
+    }]
+  }).catch(error => {
+    console.log(error);
+    return null;
+  });
+}
+
+export async function getAllSampleHubbleMeasurements(): Promise<SampleHubbleMeasurement[]> {
+  return SampleHubbleMeasurement.findAll();
 }
 
 export async function getStudentHubbleMeasurements(studentID: number): Promise<HubbleMeasurement[] | null> {

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -301,6 +301,7 @@ export async function getGalaxiesForTypes(types: string[]): Promise<Galaxy[]> {
     where: {
       is_bad: 0,
       spec_is_bad: 0,
+      is_sample: 0,
       type: { [Op.in]: types }
     }
   });
@@ -310,7 +311,8 @@ export async function getAllGalaxies(): Promise<Galaxy[]> {
   return Galaxy.findAll({
     where: {
       is_bad: 0,
-      spec_is_bad: 0
+      spec_is_bad: 0,
+      is_sample: 0
     }
   });
 }
@@ -402,6 +404,7 @@ export async function getGalaxiesForDataGeneration(types=["Sp"]): Promise<Galaxy
     where: {
       is_bad: 0,
       spec_is_bad: 0,
+      is_sample: 0,
       type: { [Op.in]: types }
     },
     include: [
@@ -430,6 +433,7 @@ export async function getGalaxiesForDataGeneration(types=["Sp"]): Promise<Galaxy
     where: {
       is_bad: 0,
       spec_is_bad: 0,
+      is_sample: 0,
       type: { [Op.in]: types },
       id: { [Op.notIn]: measurementIDs }
     },

--- a/src/stories/hubbles_law/models/galaxy.ts
+++ b/src/stories/hubbles_law/models/galaxy.ts
@@ -15,6 +15,7 @@ export class Galaxy extends Model<InferAttributes<Galaxy>, InferCreationAttribut
   declare spec_is_good: CreationOptional<number>;
   declare spec_checked: CreationOptional<number>;
   declare tileload_marked_bad: CreationOptional<number>;
+  declare is_sample: CreationOptional<number>;
 }
 
 export function initializeGalaxyModel(sequelize: Sequelize) {
@@ -77,6 +78,10 @@ export function initializeGalaxyModel(sequelize: Sequelize) {
     },
     tileload_marked_bad: {
       type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    is_sample: {
+      type: DataTypes.TINYINT,
       allowNull: false
     }
   }, {

--- a/src/stories/hubbles_law/models/index.ts
+++ b/src/stories/hubbles_law/models/index.ts
@@ -1,5 +1,6 @@
 import { Galaxy, initializeGalaxyModel } from "./galaxy";
 import { HubbleMeasurement, initializeHubbleMeasurementModel } from "./hubble_measurement";
+import { SampleHubbleMeasurement, initializeSampleHubbleMeasurementModel } from "./sample_measurement";
 import { AsyncMergedHubbleStudentClasses, initializeAsyncMergedHubbleStudentClassesModel } from "./async_merged_student_classes";
 import { SyncMergedHubbleClasses, initializeSyncMergedHubbleClassesModel } from "./sync_merged_classes";
 import { Sequelize } from "sequelize/types";
@@ -9,6 +10,7 @@ import { initializeHubbleClassDataModel } from "./hubble_class_data";
 export {
   Galaxy,
   HubbleMeasurement,
+  SampleHubbleMeasurement,
   AsyncMergedHubbleStudentClasses,
   SyncMergedHubbleClasses
 };
@@ -16,6 +18,7 @@ export {
 export function initializeModels(db: Sequelize) {
   initializeGalaxyModel(db);
   initializeHubbleMeasurementModel(db);
+  initializeSampleHubbleMeasurementModel(db);
   initializeAsyncMergedHubbleStudentClassesModel(db);
   initializeSyncMergedHubbleClassesModel(db);
   initializeHubbleStudentDataModel(db);

--- a/src/stories/hubbles_law/models/sample_measurement.ts
+++ b/src/stories/hubbles_law/models/sample_measurement.ts
@@ -1,0 +1,81 @@
+import { Galaxy } from "./galaxy";
+import { Student } from "../../../models";
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+
+export class SampleHubbleMeasurement extends Model<InferAttributes<SampleHubbleMeasurement>, InferCreationAttributes<SampleHubbleMeasurement>> {
+  declare student_id: number;
+  declare galaxy_id: number;
+
+  declare rest_wave_value: CreationOptional<number | null>;
+  declare rest_wave_unit: CreationOptional<string | null>;
+  declare obs_wave_value: CreationOptional<number | null>;
+  declare obs_wave_unit: CreationOptional<string | null>;
+  declare velocity_value: CreationOptional<number | null>;
+  declare velocity_unit: CreationOptional<string | null>;
+  declare ang_size_value: CreationOptional<number | null>;
+  declare ang_size_unit: CreationOptional<string | null>;
+  declare est_dist_value: CreationOptional<number | null>;
+  declare est_dist_unit: CreationOptional<string | null>;
+  declare last_modified: CreationOptional<Date>;
+}
+
+export function initializeSampleHubbleMeasurementModel(sequelize: Sequelize) {
+  SampleHubbleMeasurement.init({
+    student_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Student,
+        key: "id"
+      },
+    },
+    galaxy_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Galaxy,
+        key: "id"
+      }
+    },
+    rest_wave_value: {
+      type: DataTypes.FLOAT
+    },
+    rest_wave_unit: {
+      type: DataTypes.STRING
+    },
+    obs_wave_value: {
+      type: DataTypes.FLOAT
+    },
+    obs_wave_unit: {
+      type: DataTypes.STRING
+    },
+    velocity_value: {
+      type: DataTypes.FLOAT
+    },
+    velocity_unit: {
+      type: DataTypes.STRING
+    },
+    ang_size_value: {
+      type: DataTypes.FLOAT
+    },
+    ang_size_unit: {
+      type: DataTypes.STRING
+    },
+    est_dist_value: {
+      type: DataTypes.FLOAT
+    },
+    est_dist_unit: {
+      type: DataTypes.STRING
+    },
+    last_modified: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
+    }
+  }, {
+    sequelize,
+    engine: "InnoDB"
+  });
+}

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -14,6 +14,7 @@ import {
   getHubbleMeasurement,
   submitHubbleMeasurement,
   getStudentHubbleMeasurements,
+  getSampleHubbleMeasurement,
   removeHubbleMeasurement,
   setGalaxySpectrumStatus,
   getUncheckedSpectraGalaxies,
@@ -23,7 +24,8 @@ import {
   getAllHubbleClassData,
   getGalaxiesForDataGeneration,
   getNewGalaxies,
-  getGalaxiesForTypes
+  getGalaxiesForTypes,
+  getAllSampleHubbleMeasurements
 } from "./database";
 
 import { 
@@ -31,7 +33,7 @@ import {
   SubmitHubbleMeasurementResult
 } from "./request_results";
 
-import { request, Router } from "express";
+import { Router } from "express";
 
 const router = Router();
 
@@ -121,6 +123,21 @@ router.get("/measurements/:studentID/:galaxyID", async (req, res) => {
     galaxy_id: galaxyID,
     measurement: measurement
   });
+});
+
+router.get("/sample-measurements/:studentID", async (req, res) => {
+  const params = req.params;
+  const studentID = parseInt(params.studentID);
+  const measurement = await getSampleHubbleMeasurement(studentID);
+  res.json({
+    student_id: studentID,
+    measurement: measurement
+  });
+});
+
+router.get("/sample-measurements", async (_req, res) => {
+  const measurements = await getAllSampleHubbleMeasurements();
+  res.json(measurements);
 });
 
 

--- a/src/stories/hubbles_law/sql/create_galaxy_table.sql
+++ b/src/stories/hubbles_law/sql/create_galaxy_table.sql
@@ -11,6 +11,9 @@ CREATE TABLE Galaxies(
     spec_marked_bad int NOT NULL DEFAULT 0,
     spec_is_bad tinyint(2) NOT NULL DEFAULT 0,
     tileload_marked_bad int NOT NULL DEFAULT 0,
+    spec_is_good tinyint(2) NOT NULL DEFAULT 0,
+    spec_checked tinyint(2) NOT NULL DEFAULT 0,
+    is_sample tinyint(2) NOT NULL DEFAULT 0,
 
     PRIMARY KEY(id)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;

--- a/src/stories/hubbles_law/sql/create_sample_measurements_table.sql
+++ b/src/stories/hubbles_law/sql/create_sample_measurements_table.sql
@@ -1,0 +1,29 @@
+CREATE TABLE SampleHubbleMeasurements (
+    student_id int(11) UNSIGNED NOT NULL,
+    galaxy_id int(11) UNSIGNED NOT NULL,
+
+    rest_wave_value FLOAT,
+    rest_wave_unit varchar(20),
+    obs_wave_value FLOAT,
+    obs_wave_unit varchar(20),
+    velocity_value FLOAT,
+    velocity_unit varchar(20),
+    ang_size_value int(11),
+    ang_size_unit varchar(20),
+    est_dist_value int(11),
+    est_dist_unit varchar(20),
+    last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY(student_id, galaxy_id),
+    INDEX(student_id),
+    INDEX(galaxy_id),
+    FOREIGN KEY(student_id)
+      REFERENCES Students(id)
+      ON UPDATE CASCADE
+      ON DELETE CASCADE,
+    FOREIGN KEY(galaxy_id)
+      REFERENCES Galaxies(id)
+      ON UPDATE CASCADE
+      ON DELETE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;


### PR DESCRIPTION
This PR updates the Sequelize models, SQL definitions, and existing server endpoints to account for the fact that we have designated galaxy spec-1572-53177-0186 as a "sample" galaxy that every student will do a measurement for (this is the only galaxy for which `is_sample = 1`). This PR also adds new endpoints for getting the sample measurements (either all of them or for a single student) from the database.