### PR TITLE
Add endpoint that returns sample galaxy data

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -389,6 +389,12 @@ export async function getGalaxyByName(name: string): Promise<Galaxy | null> {
   });
 }
 
+export async function getSampleGalaxy(): Promise<Galaxy | null> {
+  return Galaxy.findOne({
+    where: { is_sample: 1 }
+  });
+}
+
 export async function markGalaxyBad(galaxy: Galaxy): Promise<void> {
   galaxy.update({ marked_bad: galaxy.marked_bad + 1 });
 }

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -25,7 +25,8 @@ import {
   getGalaxiesForDataGeneration,
   getNewGalaxies,
   getGalaxiesForTypes,
-  getAllSampleHubbleMeasurements
+  getAllSampleHubbleMeasurements,
+  getSampleGalaxy
 } from "./database";
 
 import { 
@@ -140,6 +141,10 @@ router.get("/sample-measurements", async (_req, res) => {
   res.json(measurements);
 });
 
+router.get("/sample-galaxy", async (_req, res) => {
+  const galaxy = await getSampleGalaxy();
+  res.json(galaxy);
+});
 
 router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
   const params = req.params;


### PR DESCRIPTION
This PR adds a `/hubbles_law/sample-galaxy` endpoint that returns the data for our sample galaxy.