### PR TITLE
Allow submitting sample measurements

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -389,6 +389,12 @@ export async function getGalaxyByName(name: string): Promise<Galaxy | null> {
   });
 }
 
+export async function getGalaxyById(id: number): Promise<Galaxy | null> {
+  return Galaxy.findOne({
+    where: { id: id }
+  });
+}
+
 export async function getSampleGalaxy(): Promise<Galaxy | null> {
   return Galaxy.findOne({
     where: { is_sample: 1 }

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -13,6 +13,7 @@ import {
   markGalaxyTileloadBad,
   getHubbleMeasurement,
   submitHubbleMeasurement,
+  submitSampleHubbleMeasurement,
   getStudentHubbleMeasurements,
   getSampleHubbleMeasurement,
   removeHubbleMeasurement,
@@ -111,7 +112,7 @@ router.put("/submit-sample-measurement", async (req, res) => {
 
   let result: SubmitHubbleMeasurementResult;
   if (valid || galaxy === null || galaxy.is_sample === 0) {
-    result = await submitHubbleMeasurement(data);
+    result = await submitSampleHubbleMeasurement(data);
   } else {
     result = SubmitHubbleMeasurementResult.BadRequest;
   }


### PR DESCRIPTION
This PR adds a `/hubbles_law/submit-sample-measurements` endpoint that allows for the submission of sample measurements (measurements of the sample galaxy that every student will measure).