### PR TITLE
Change Student model to have default seed value of 0

### DIFF
--- a/src/models/student.ts
+++ b/src/models/student.ts
@@ -93,7 +93,8 @@ export function initializeStudentModel(sequelize: Sequelize) {
     },
     seed: {
       type: DataTypes.TINYINT,
-      allowNull: false
+      allowNull: false,
+      defaultValue: 0
     },
     team_member: {
       type: DataTypes.STRING


### PR DESCRIPTION
This PR changes the `Student` Sequelize model to have a default value of 0 for the `seed` property, which matches the SQL definition in the database table.