### PR TITLE
Updates to account for two sample data points

### DIFF
--- a/src/stories/hubbles_law/models/sample_measurement.ts
+++ b/src/stories/hubbles_law/models/sample_measurement.ts
@@ -17,6 +17,7 @@ export class SampleHubbleMeasurement extends Model<InferAttributes<SampleHubbleM
   declare est_dist_value: CreationOptional<number | null>;
   declare est_dist_unit: CreationOptional<string | null>;
   declare last_modified: CreationOptional<Date>;
+  declare measurement_number: CreationOptional<string>;
 }
 
 export function initializeSampleHubbleMeasurementModel(sequelize: Sequelize) {
@@ -38,6 +39,12 @@ export function initializeSampleHubbleMeasurementModel(sequelize: Sequelize) {
         model: Galaxy,
         key: "id"
       }
+    },
+    measurement_number: {
+      type: DataTypes.ENUM("first", "second"),
+      allowNull: false,
+      defaultValue: "first",
+      primaryKey: true
     },
     rest_wave_value: {
       type: DataTypes.FLOAT

--- a/src/stories/hubbles_law/sql/create_sample_measurements_table.sql
+++ b/src/stories/hubbles_law/sql/create_sample_measurements_table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE SampleHubbleMeasurements (
     student_id int(11) UNSIGNED NOT NULL,
     galaxy_id int(11) UNSIGNED NOT NULL,
-
+    measurement_number ENUM('first', 'second') NOT NULL DEFAULT 'first',
     rest_wave_value FLOAT,
     rest_wave_unit varchar(20),
     obs_wave_value FLOAT,
@@ -15,7 +15,7 @@ CREATE TABLE SampleHubbleMeasurements (
     last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
         ON UPDATE CURRENT_TIMESTAMP,
 
-    PRIMARY KEY(student_id, galaxy_id),
+    PRIMARY KEY(student_id, galaxy_id, measurement_number),
     INDEX(student_id),
     INDEX(galaxy_id),
     FOREIGN KEY(student_id)


### PR DESCRIPTION
This PR contains updates to account for the database update that allows for two sample data points. In the database, this is done by adding a `measurement_number` field, which is a MySQL `ENUM` that can take the values `"first"` and `"second"` (the primary key has been updated to be `(student_id, galaxy_id, measurement_number)`. These commits update the SQL definition accordingly, as well as the Sequelize model, and add/modify some relevant sample measurement endpoints.