### PR TITLE
Add student options

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -30,6 +30,7 @@ import { User } from "./user";
 
 import { setUpAssociations } from "./associations";
 import { initializeModels } from "./models";
+import { StudentOption, StudentOptions } from "./models/student_options";
 
 type SequelizeError = { parent: { code: string } };
 
@@ -568,4 +569,24 @@ export async function classForStudentStory(studentID: number, storyName: string)
       }
     ]
   });
+}
+
+export async function getStudentOptions(studentID: number): Promise<StudentOptions | null> {
+  return StudentOptions.findOne({ where: { student_id: studentID } }).catch((_error) => null);
+}
+
+async function createStudentOptions(studentID: number): Promise<StudentOptions | null> {
+  return StudentOptions.create({student_id: studentID}).catch((_error) => null);
+}
+
+// Change the typing of value as we add more student options
+export async function setStudentOption(studentID: number, option: StudentOption, value: number): Promise<StudentOptions | null> {
+  let options = await getStudentOptions(studentID);
+  if (options === null) {
+    options = await createStudentOptions(studentID);
+  }
+  if (options !== null) {
+    options.update({ [option]: value });
+  }
+  return options;
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,6 +8,7 @@ import { Story, initializeStoryModel } from "./story";
 import { StudentsClasses, initializeStudentClassModel } from "./student_class";
 import { Student, initializeStudentModel } from "./student";
 import { Sequelize } from "sequelize/types";
+import { initializeStudentOptionsModel } from "./student_options";
 
 export {
   Class,
@@ -31,4 +32,5 @@ export function initializeModels(db: Sequelize) {
   initializeDummyClassModel(db);
   initializeStoryStateModel(db);
   initializeStudentClassModel(db);
+  initializeStudentOptionsModel(db);
 }

--- a/src/models/student_options.ts
+++ b/src/models/student_options.ts
@@ -8,6 +8,7 @@ export class StudentOptions extends Model<InferAttributes<StudentOptions>, Infer
   declare speech_pitch: CreationOptional<number>;
 }
 
+// TODO: Can we generate this automatically from the class definition?
 const STUDENT_OPTIONS = ["speech_autoread", "speech_rate", "speech_pitch"] as const;
 export type StudentOption = (typeof STUDENT_OPTIONS)[number];
 

--- a/src/models/student_options.ts
+++ b/src/models/student_options.ts
@@ -8,16 +8,23 @@ export class StudentOptions extends Model<InferAttributes<StudentOptions>, Infer
   declare speech_pitch: CreationOptional<number>;
 }
 
-export function initializeStudentOptions(sequelize: Sequelize) {
+const STUDENT_OPTIONS = ["speech_autoread", "speech_rate", "speech_pitch"] as const;
+export type StudentOption = (typeof STUDENT_OPTIONS)[number];
+
+export function isStudentOption(o: any): o is StudentOption {
+  return typeof o === "string" && ([...STUDENT_OPTIONS] as string[]).includes(o);
+}
+
+export function initializeStudentOptionsModel(sequelize: Sequelize) {
   StudentOptions.init({
     student_id: {
       type: DataTypes.INTEGER.UNSIGNED,
       allowNull: false,
-        primaryKey: true,
-        references: {
-          model: Student,
-          key: "id"
-        }
+      primaryKey: true,
+      references: {
+        model: Student,
+        key: "id"
+      }
     },
     speech_autoread: {
       type: DataTypes.TINYINT,

--- a/src/models/student_options.ts
+++ b/src/models/student_options.ts
@@ -1,0 +1,41 @@
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+import { Student } from "./student";
+
+export class StudentOptions extends Model<InferAttributes<StudentOptions>, InferCreationAttributes<StudentOptions>> {
+  declare student_id: number;
+  declare speech_autoread: CreationOptional<number>;
+  declare speech_rate: CreationOptional<number>;
+  declare speech_pitch: CreationOptional<number>;
+}
+
+export function initializeStudentOptions(sequelize: Sequelize) {
+  StudentOptions.init({
+    student_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+        primaryKey: true,
+        references: {
+          model: Student,
+          key: "id"
+        }
+    },
+    speech_autoread: {
+      type: DataTypes.TINYINT,
+      allowNull: false,
+      defaultValue: 0
+    },
+    speech_rate: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      defaultValue: 1
+    },
+    speech_pitch: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      defaultValue: 1
+    }
+  }, {
+    sequelize,
+    engine: "InnoDB"
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,8 @@ import {
   findStudentById,
   findStudentByUsername,
   classForStudentStory,
+  getStudentOptions,
+  setStudentOption,
   
 } from "./database";
 
@@ -43,6 +45,7 @@ import sequelizeStore from "connect-session-sequelize";
 import { v4 } from "uuid";
 import cors from "cors";
 import jwt from "jsonwebtoken";
+import { isStudentOption } from "./models/student_options";
 export const app = express();
 
 // TODO: Clean up these type definitions
@@ -462,4 +465,33 @@ app.get("/class-for-student-story/:studentID/:storyName", async (req, res) => {
   if (cls == null) {
     res.statusCode = 404;
   }
+});
+
+app.get("/options/:studentID", async (req, res) => {
+  const studentID = parseInt(req.params.studentID);
+  const options = await getStudentOptions(studentID);
+  res.json({options});
+  if (options == null) {
+    res.statusCode = 404;
+  }
+});
+
+app.put("/options/:studentID", async (req, res) => {
+  const studentID = parseInt(req.params.studentID);
+  const option = req.body.option;
+  const value = req.body.value;
+  if (!isStudentOption(option)) {
+    res.statusCode = 404;
+    res.statusMessage = `${option} is not a valid option`;
+    res.send();
+    return;
+  }
+  const updatedOptions = await setStudentOption(studentID, option, value);
+  if (updatedOptions === null) {
+    res.statusCode = 404;
+    res.statusMessage = "Invalid student ID";
+    res.send();
+    return;
+  }
+  res.json({updated_options: updatedOptions});
 });

--- a/src/sql/create_student_options_table.sql
+++ b/src/sql/create_student_options_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE StudentOptions (
+    student_id int(11) UNSIGNED NOT NULL,
+    speech_autoread tinyint(2) NOT NULL DEFAULT 0,
+    speech_rate FLOAT NOT NULL DEFAULT 1,
+    speech_pitch FLOAT NOT NULL DEFAULT 1,
+
+    PRIMARY KEY(student_id),
+    FOREIGN KEY(student_id)
+        REFERENCES Students(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;


### PR DESCRIPTION
This PR adds an additional model, `StudentOptions`, as well as relevant endpoints. This model represents global (i.e. across stories) options for students. Currently, the only such options are related to the speech synthesis functionality (auto-reading, rate, and pitch).