### PR TITLE
Filter out sample measurements with null values by default

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -159,8 +159,17 @@ export async function getSampleHubbleMeasurement(studentID: number, measurementN
   });
 }
 
-export async function getAllSampleHubbleMeasurements(): Promise<SampleHubbleMeasurement[]> {
-  return SampleHubbleMeasurement.findAll().catch(_error => []);
+export async function getAllSampleHubbleMeasurements(excludeWithNull = true): Promise<SampleHubbleMeasurement[]> {
+  const query = excludeWithNull ? 
+  {
+    where: {
+      obs_wave_value: { [Op.not]: null },
+      velocity_value: { [Op.not]: null },
+      ang_size_value: { [Op.not]: null },
+      est_dist_value: { [Op.not]: null }
+    }
+  } : {};
+  return SampleHubbleMeasurement.findAll(query).catch(_error => []);
 }
 
 export async function getAllNthSampleHubbleMeasurements(measurementNumber: "first" | "second"): Promise<SampleHubbleMeasurement[]> {

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -219,8 +219,10 @@ router.get("/sample-measurements/:studentID/:measurementNumber", async (req, res
   });
 });
 
-router.get("/sample-measurements", async (_req, res) => {
-  const measurements = await getAllSampleHubbleMeasurements();
+router.get("/sample-measurements", async (req, res) => {
+  const filterNullString = ((req.query.filter_null as string) ?? "true").toLowerCase();
+  const filterNull = filterNullString !== "false";
+  const measurements = await getAllSampleHubbleMeasurements(filterNull);
   res.json(measurements);
 });
 


### PR DESCRIPTION
This PR updates the Hubble `GET /sample-measurements` endpoint to filter out sample measurements by default. If unfinished measurements are needed for some reason, we can get them with `/sample_measurements?filter_null=false`.