### PR TITLE
Add brightness to measurements

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -24,7 +24,8 @@ export async function submitHubbleMeasurement(data: {
   ang_size_value: number | null,
   ang_size_unit: string | null,
   est_dist_value: number | null,
-  est_dist_unit: string | null
+  est_dist_unit: string | null,
+  brightness?: number
 }): Promise<SubmitHubbleMeasurementResult> {
 
   const student = await findStudentById(data.student_id);
@@ -72,7 +73,8 @@ export async function submitSampleHubbleMeasurement(data: {
   ang_size_value: number | null,
   ang_size_unit: string | null,
   est_dist_value: number | null,
-  est_dist_unit: string | null
+  est_dist_unit: string | null,
+  brightness?: number,
 }): Promise<SubmitHubbleMeasurementResult> {
 
   const student = await findStudentById(data.student_id);

--- a/src/stories/hubbles_law/models/hubble_measurement.ts
+++ b/src/stories/hubbles_law/models/hubble_measurement.ts
@@ -16,6 +16,7 @@ export class HubbleMeasurement extends Model<InferAttributes<HubbleMeasurement>,
   declare ang_size_unit: CreationOptional<string | null>;
   declare est_dist_value: CreationOptional<number | null>;
   declare est_dist_unit: CreationOptional<string | null>;
+  declare brightness: CreationOptional<number>;
   declare last_modified: CreationOptional<Date>;
 }
 
@@ -68,6 +69,11 @@ export function initializeHubbleMeasurementModel(sequelize: Sequelize) {
     },
     est_dist_unit: {
       type: DataTypes.STRING
+    },
+    brightness: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      defaultValue: 1
     },
     last_modified: {
       type: DataTypes.DATE,

--- a/src/stories/hubbles_law/models/sample_measurement.ts
+++ b/src/stories/hubbles_law/models/sample_measurement.ts
@@ -16,6 +16,7 @@ export class SampleHubbleMeasurement extends Model<InferAttributes<SampleHubbleM
   declare ang_size_unit: CreationOptional<string | null>;
   declare est_dist_value: CreationOptional<number | null>;
   declare est_dist_unit: CreationOptional<string | null>;
+  declare brightness: CreationOptional<number>;
   declare last_modified: CreationOptional<Date>;
   declare measurement_number: CreationOptional<string>;
 }
@@ -75,6 +76,11 @@ export function initializeSampleHubbleMeasurementModel(sequelize: Sequelize) {
     },
     est_dist_unit: {
       type: DataTypes.STRING
+    },
+    brightness: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      defaultValue: 1
     },
     last_modified: {
       type: DataTypes.DATE,

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -57,7 +57,8 @@ router.put("/submit-measurement", async (req, res) => {
     (!data.ang_size_value || typeof data.ang_size_value === "number") &&
     (!data.ang_size_unit || typeof data.ang_size_unit === "string") &&
     (!data.est_dist_value || typeof data.est_dist_value === "number") &&
-    (!data.est_dist_unit || typeof data.est_dist_unit === "string")
+    (!data.est_dist_unit || typeof data.est_dist_unit === "string") &&
+    (!data.brightness || typeof data.brightness === "number")
   );
 
   if (typeof data.galaxy_id !== "number") {
@@ -98,7 +99,8 @@ router.put("/sample-measurement", async (req, res) => {
     (!data.ang_size_unit || typeof data.ang_size_unit === "string") &&
     (!data.est_dist_value || typeof data.est_dist_value === "number") &&
     (!data.est_dist_unit || typeof data.est_dist_unit === "string") &&
-    (!data.measurement_number || typeof data.measurement_number == "string")
+    (!data.measurement_number || typeof data.measurement_number == "string") &&
+    (!data.brightness || typeof data.brightness === "number")
   );
 
   let galaxy;

--- a/src/stories/hubbles_law/sql/create_hubble_measurements_table.sql
+++ b/src/stories/hubbles_law/sql/create_hubble_measurements_table.sql
@@ -12,6 +12,7 @@ CREATE TABLE HubbleMeasurements (
     ang_size_unit varchar(20),
     est_dist_value int(11),
     est_dist_unit varchar(20),
+    brightness FLOAT NOT NULL DEFAULT 1,
     last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
         ON UPDATE CURRENT_TIMESTAMP,
 

--- a/src/stories/hubbles_law/sql/create_sample_measurements_table.sql
+++ b/src/stories/hubbles_law/sql/create_sample_measurements_table.sql
@@ -12,6 +12,7 @@ CREATE TABLE SampleHubbleMeasurements (
     ang_size_unit varchar(20),
     est_dist_value int(11),
     est_dist_unit varchar(20),
+    brightness FLOAT NOT NULL DEFAULT 1,
     last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
         ON UPDATE CURRENT_TIMESTAMP,
 


### PR DESCRIPTION
This PR adds the necessary infrastructure to account for the addition of a brightness column to both the regular and sample measurement database tables.