### PR TITLE
Relax class size limit

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -383,7 +383,7 @@ export async function getAllHubbleClassData(): Promise<HubbleClassData[]> {
       attributes: []
     }],
     group: ["HubbleClassData.class_id"],
-    having: Sequelize.where(Sequelize.fn("count", Sequelize.col("HubbleClassData.class_id")), { [Op.gte]: 15 })
+    having: Sequelize.where(Sequelize.fn("count", Sequelize.col("HubbleClassData.class_id")), { [Op.gte]: 13 })
   });
 }
 


### PR DESCRIPTION
This PR relaxes the class size limit for data to be delivered to a student using the app from 15 down to 13 (counting extra students that we made just in case, this is the size of the smaller of the classes from the first beta test).