### PR TITLE
Add `last_checked` parameter to stage 3 data route

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -284,7 +284,7 @@ async function getHubbleMeasurementsForAsyncStudent(studentID: number, classID: 
   return getHubbleMeasurementsForClasses(classIDs);
 }
 
-export async function getStageThreeMeasurements(studentID: number, classID: number | null): Promise<HubbleMeasurement[]> {
+export async function getStageThreeMeasurements(studentID: number, classID: number | null, lastChecked: Date | null = null): Promise<HubbleMeasurement[]> {
   const cls = classID !== null ? await findClassById(classID) : null;
   const asyncClass = cls?.asynchronous ?? true;
   let data: HubbleMeasurement[] | null;
@@ -292,6 +292,13 @@ export async function getStageThreeMeasurements(studentID: number, classID: numb
     data = await getHubbleMeasurementsForAsyncStudent(studentID, classID);
   } else {
     data = await getHubbleMeasurementsForSyncClass(classID);
+  }
+  if (data != null) {
+    const checked = lastChecked ?? new Date();
+    const lastModified = Math.max(...data.map(meas => meas.last_modified.getUTCMilliseconds()));
+    if (lastModified < checked.getUTCMilliseconds()) {
+      data = null;
+    }
   }
   return data ?? [];
 }

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -284,7 +284,7 @@ async function getHubbleMeasurementsForAsyncStudent(studentID: number, classID: 
   return getHubbleMeasurementsForClasses(classIDs);
 }
 
-export async function getStageThreeMeasurements(studentID: number, classID: number | null, lastChecked: Date | null = null): Promise<HubbleMeasurement[]> {
+export async function getStageThreeMeasurements(studentID: number, classID: number | null, lastChecked: number | null = null): Promise<HubbleMeasurement[]> {
   const cls = classID !== null ? await findClassById(classID) : null;
   const asyncClass = cls?.asynchronous ?? true;
   let data: HubbleMeasurement[] | null;
@@ -293,10 +293,9 @@ export async function getStageThreeMeasurements(studentID: number, classID: numb
   } else {
     data = await getHubbleMeasurementsForSyncClass(classID);
   }
-  if (data != null) {
-    const checked = lastChecked ?? new Date();
-    const lastModified = Math.max(...data.map(meas => meas.last_modified.getUTCMilliseconds()));
-    if (lastModified < checked.getUTCMilliseconds()) {
+  if (data != null && lastChecked != null) {
+    const lastModified = Math.max(...data.map(meas => meas.last_modified.getTime()));
+    if (lastModified <= lastChecked) {
       data = null;
     }
   }

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -246,13 +246,9 @@ router.get("/sample-galaxy", async (_req, res) => {
 
 router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
   const lastCheckedStr = req.query.last_checked as string;
-  let lastChecked;
-  if (lastCheckedStr) {
-    try {
-      lastChecked = new Date(lastCheckedStr);
-    } catch {
-      lastChecked = null;
-    }
+  let lastChecked: number | null = parseInt(lastCheckedStr);
+  if (isNaN(lastChecked)) {
+    lastChecked = null;
   }
   const params = req.params;
   let studentID = parseInt(params.studentID);

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -245,6 +245,15 @@ router.get("/sample-galaxy", async (_req, res) => {
 });
 
 router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
+  const lastCheckedStr = req.query.last_checked as string;
+  let lastChecked;
+  if (lastCheckedStr) {
+    try {
+      lastChecked = new Date(lastCheckedStr);
+    } catch {
+      lastChecked = null;
+    }
+  }
   const params = req.params;
   let studentID = parseInt(params.studentID);
   let classID = parseInt(params.classID);
@@ -254,7 +263,7 @@ router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
   if (classID === 0) {
     classID = 159;
   }
-  const measurements = await getStageThreeMeasurements(studentID, classID);
+  const measurements = await getStageThreeMeasurements(studentID, classID, lastChecked);
   res.json({
     studentID,
     classID,


### PR DESCRIPTION
This PR adds support for a `last_checked` query parameter to the `/stage-3-data` endpoint (which is poorly named after the stage refactor, but not a problem for right now). This value of this parameter should be an integer that represents a Unix timestamp (in milliseconds). If none of the class data points have been changed since this timestamp, an empty array is returned to indicate that nothing has updated.

The idea behind this is to avoid sending the class data on every endpoint hit. While the data returned on any particular request shouldn't be large, this request gets fired a lot from the Hubble story. Hopefully returning an empty payload most of the time will yield a decent reduction in network traffic.