### PR TITLE
Add functionality for excluding certain student measurements

### DIFF
--- a/src/associations.ts
+++ b/src/associations.ts
@@ -4,6 +4,7 @@ import { Story } from "./models/story";
 import { StudentsClasses } from "./models/student_class";
 import { ClassStories } from "./models/story_class";
 import { StoryState } from "./models/story_state";
+import { IgnoreStudent } from "./models/ignore_student";
 
 export function setUpAssociations() {
 
@@ -59,6 +60,24 @@ export function setUpAssociations() {
     foreignKey: "story_name"
   });
   StoryState.belongsTo(Story, {
+    as: "story",
+    targetKey: "name",
+    foreignKey: "story_name"
+  });
+
+  Student.hasMany(IgnoreStudent, {
+    foreignKey: "student_id"
+  });
+  IgnoreStudent.belongsTo(Student, {
+    as: "student",
+    targetKey: "id",
+    foreignKey: "student_id"
+  });
+
+  Story.hasMany(IgnoreStudent, {
+    foreignKey: "story_name"
+  });
+  IgnoreStudent.belongsTo(Story, {
     as: "story",
     targetKey: "name",
     foreignKey: "story_name"

--- a/src/models/ignore_student.ts
+++ b/src/models/ignore_student.ts
@@ -1,0 +1,34 @@
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes } from "sequelize";
+import { Story } from "./story";
+import { Student } from "./student";
+
+export class IgnoreStudent extends Model<InferAttributes<IgnoreStudent>, InferCreationAttributes<IgnoreStudent>> {
+  declare student_id: number;
+  declare story_name: string;
+}
+
+export function initializeIgnoreStudentModel(sequelize: Sequelize) {
+  IgnoreStudent.init({
+    student_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Student,
+        key: "id"
+      }
+    },
+    story_name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Story,
+        key: "name"
+      }
+    }
+  }, {
+    sequelize,
+    engine: "InnoDB"
+  });
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,6 +1,7 @@
 import { Class, initializeClassModel } from "./class";
 import { DummyClass, initializeDummyClassModel } from "./dummy_class";
 import { Educator, initializeEducatorModel } from "./educator";
+import { IgnoreStudent, initializeIgnoreStudentModel } from "./ignore_student";
 import { ClassStories, initializeClassStoryModel } from "./story_class";
 import { CosmicDSSession, initializeSessionModel } from "./session";
 import { StoryState, initializeStoryStateModel } from "./story_state";
@@ -16,12 +17,12 @@ export {
   CosmicDSSession,
   DummyClass,
   Educator,
+  IgnoreStudent,
   Story,
   StoryState,
   Student,
   StudentsClasses,
 };
-
 export function initializeModels(db: Sequelize) {
   initializeSessionModel(db);
   initializeEducatorModel(db);
@@ -33,4 +34,5 @@ export function initializeModels(db: Sequelize) {
   initializeStoryStateModel(db);
   initializeStudentClassModel(db);
   initializeStudentOptionsModel(db);
+  initializeIgnoreStudentModel(db);
 }

--- a/src/sql/create_ignore_students_table.sql
+++ b/src/sql/create_ignore_students_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IgnoreStudents (
+    student_id int(11) UNSIGNED NOT NULL,
+    story_name varchar(50) NOT NULL,
+
+    PRIMARY KEY(student_id, story_name),
+    INDEX(student_id),
+    INDEX(story_name),
+    FOREIGN KEY(student_id)
+        REFERENCES Students(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    FOREIGN KEY(story_name)
+        REFERENCES Stories(name)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -6,6 +6,7 @@ import { setUpHubbleAssociations } from "./associations";
 import { Class, Student, StudentsClasses } from "../../models";
 import { HubbleStudentData } from "./models/hubble_student_data";
 import { HubbleClassData } from "./models/hubble_class_data";
+import { IgnoreStudent } from "../../models/ignore_student";
 
 initializeModels(cosmicdsDB);
 setUpHubbleAssociations();
@@ -169,7 +170,7 @@ export async function getAllSampleHubbleMeasurements(excludeWithNull = true): Pr
       velocity_value: { [Op.not]: null },
       ang_size_value: { [Op.not]: null },
       est_dist_value: { [Op.not]: null }
-    }
+    },
   } : {};
   return SampleHubbleMeasurement.findAll(query).catch(_error => []);
 }
@@ -201,6 +202,9 @@ export async function getStudentHubbleMeasurements(studentID: number): Promise<H
 async function getHubbleMeasurementsForClasses(classIDs: number[]): Promise<HubbleMeasurement[]> {
 
   return HubbleMeasurement.findAll({
+    where: {
+      "$student.IgnoreStudents.student_id$": null
+    },
     include: [{
       model: Student,
       attributes: ["id"],
@@ -214,7 +218,15 @@ async function getHubbleMeasurementsForClasses(classIDs: number[]): Promise<Hubb
             [Op.in]: classIDs
           }
         }
-      }]
+      },
+      {
+        model: IgnoreStudent,
+        required: false,
+        attributes: ["student_id", "story_name"],
+        where: {
+          story_name: "hubbles_law"
+        }
+      }],
     },
     {
       model: Galaxy,
@@ -331,6 +343,9 @@ export async function getAllHubbleMeasurements(): Promise<HubbleMeasurement[]> {
       // We do this so that we get access to the included field as just "class_id"
       include: [[Sequelize.col("student.Classes.id"), "class_id"]]
     },
+    where: {
+      "$student.IgnoreStudents.student_id$": null
+    },
     include: [{
       model: Galaxy,
       as: "galaxy",
@@ -348,6 +363,14 @@ export async function getAllHubbleMeasurements(): Promise<HubbleMeasurement[]> {
         model: Class,
         attributes: [],
         through: { attributes: [] }
+      },
+      {
+        model: IgnoreStudent,
+        required: false,
+        attributes: ["student_id", "story_name"],
+        where: {
+          story_name: "hubbles_law"
+        }
       }]
     }]
   });
@@ -361,20 +384,31 @@ export async function getAllHubbleStudentData(): Promise<HubbleStudentData[]> {
       // We do this so that we get access to the included field as just "class_id"
       include: [[Sequelize.col("student.Classes.id"), "class_id"]]
     },
+    where: {
+      "$student.IgnoreStudents.student_id$": null
+    },
     include: [{
       model: Student,
       as: "student",
       attributes: ["seed", "dummy"],
-      where: {
-        [Op.or]: [
-          { seed: 1 }, { dummy: 0 }
-        ]
-      },
       include: [{
+        model: IgnoreStudent,
+        required: false,
+        attributes: ["student_id", "story_name"],
+        where: {
+          story_name: "hubbles_law"
+        }
+      },
+      {
         model: Class,
         attributes: [],
         through: { attributes: [] }
-      }]
+      }],
+      where: {
+         [Op.or]: [
+          { seed: 1 }, { dummy: 0 }
+        ]
+      }
     }],
   });
 

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -222,7 +222,7 @@ async function getHubbleMeasurementsForClasses(classIDs: number[]): Promise<Hubb
       {
         model: IgnoreStudent,
         required: false,
-        attributes: ["student_id", "story_name"],
+        attributes: [],
         where: {
           story_name: "hubbles_law"
         }
@@ -367,7 +367,7 @@ export async function getAllHubbleMeasurements(): Promise<HubbleMeasurement[]> {
       {
         model: IgnoreStudent,
         required: false,
-        attributes: ["student_id", "story_name"],
+        attributes: [],
         where: {
           story_name: "hubbles_law"
         }
@@ -394,7 +394,7 @@ export async function getAllHubbleStudentData(): Promise<HubbleStudentData[]> {
       include: [{
         model: IgnoreStudent,
         required: false,
-        attributes: ["student_id", "story_name"],
+        attributes: [],
         where: {
           story_name: "hubbles_law"
         }

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -244,6 +244,9 @@ async function getHubbleStudentDataForClasses(classIDs: number[]): Promise<Hubbl
       attributes: ["id"],
       as: "student",
       required: true,
+      where: {
+        "$IgnoreStudents.student_id$": null
+      },
       include: [{
         model: Class,
         attributes: ["id"],
@@ -251,6 +254,14 @@ async function getHubbleStudentDataForClasses(classIDs: number[]): Promise<Hubbl
           id: {
             [Op.in]: classIDs
           }
+        }
+      },
+      {
+        model: IgnoreStudent,
+        required: false,
+        attributes: ["student_id", "story_name"],
+        where: {
+          student_id: null
         }
       }]
     }]

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -202,9 +202,6 @@ export async function getStudentHubbleMeasurements(studentID: number): Promise<H
 async function getHubbleMeasurementsForClasses(classIDs: number[]): Promise<HubbleMeasurement[]> {
 
   return HubbleMeasurement.findAll({
-    where: {
-      "$student.IgnoreStudents.student_id$": null
-    },
     include: [{
       model: Student,
       attributes: ["id"],
@@ -244,9 +241,6 @@ async function getHubbleStudentDataForClasses(classIDs: number[]): Promise<Hubbl
       attributes: ["id"],
       as: "student",
       required: true,
-      where: {
-        "$IgnoreStudents.student_id$": null
-      },
       include: [{
         model: Class,
         attributes: ["id"],


### PR DESCRIPTION
This PR adds some infrastructure to allow us to ignore data for a given student in a given story. The intended use case here is for real students whose data are unusual enough that we don't want them to show up in whatever visualizations the story contains.

I've set this up so that we can specify a given student/story pair - this means that if we're ever at a point where a student uses the same account for multiple stories, we can choose to only ignore their data for a particular story. This is accomplished via an `IgnoreStudents` join table that we then use in our queries.