### PR TITLE
Return class size when getting class for student/story combination

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -571,6 +571,14 @@ export async function classForStudentStory(studentID: number, storyName: string)
   });
 }
 
+export async function classSize(classID: number): Promise<number> {
+  return StudentsClasses.count({
+    where: {
+      class_id: classID
+    }
+  });
+}
+
 export async function getStudentOptions(studentID: number): Promise<StudentOptions | null> {
   return StudentOptions.findOne({ where: { student_id: studentID } }).catch((_error) => null);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import {
   classForStudentStory,
   getStudentOptions,
   setStudentOption,
+  classSize,
   
 } from "./database";
 
@@ -485,11 +486,13 @@ app.get("/class-for-student-story/:studentID/:storyName", async (req, res) => {
   const studentID = parseInt(req.params.studentID);
   const storyName = req.params.storyName;
   const cls = isNaN(studentID) ? null : await classForStudentStory(studentID, storyName);
+  const size = cls != null ? await classSize(cls.id) : 0;
   if (cls == null) {
     res.statusCode = 404;
   }
   res.json({
-    class: cls
+    class: cls,
+    size
   });
 });
 


### PR DESCRIPTION
This PR modifies the `/class-for-student-story` endpoint to return the size of the class (determined by a query on the `StudentsClasses` table). This is the endpoint that the Hubble app hits to determine which class info. This allows the app to know the size of the class, to use for things like the stage 4 waiting screen. Presumably future stories will be able to make use of this information as well.