### PR TITLE
Fix issue with parsing usernames as IDs

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -375,7 +375,7 @@ app.get("/educators", async (_req, res) => {
 
 app.get("/story-state/:studentID/:storyName", async (req, res) => {
   const params = req.params;
-  const studentID = parseInt(params.studentID);
+  const studentID = Number(params.studentID);
   const storyName = params.storyName;
   const state = await getStoryState(studentID, storyName);
   const status = state !== null ? 200 : 404;
@@ -388,7 +388,7 @@ app.get("/story-state/:studentID/:storyName", async (req, res) => {
 
 app.put("/story-state/:studentID/:storyName", async (req, res) => {
   const params = req.params;
-  const studentID = parseInt(params.studentID);
+  const studentID = Number(params.studentID);
   const storyName = params.storyName;
   const newState = req.body;
   const state = await updateStoryState(studentID, storyName, newState);
@@ -402,7 +402,7 @@ app.put("/story-state/:studentID/:storyName", async (req, res) => {
 
 app.get("/educator-classes/:educatorID", async (req, res) => {
   const params = req.params;
-  const educatorID = parseInt(params.educatorID);
+  const educatorID = Number(params.educatorID);
   const classes = await getClassesForEducator(educatorID);
   res.json({
     educator_id: educatorID,
@@ -412,7 +412,7 @@ app.get("/educator-classes/:educatorID", async (req, res) => {
 
 app.get("/student-classes/:studentID", async (req, res) => {
   const params = req.params;
-  const studentID = parseInt(params.studentID);
+  const studentID = Number(params.studentID);
   const classes = await getClassesForStudent(studentID);
   res.json({
     student_id: studentID,
@@ -422,14 +422,14 @@ app.get("/student-classes/:studentID", async (req, res) => {
 
 app.get("/roster-info/:classID", async (req, res) => {
   const params = req.params;
-  const classID = parseInt(params.classID);
+  const classID = Number(params.classID);
   const info = await getRosterInfo(classID);
   res.json(info);
 });
 
 app.get("/roster-info/:classID/:storyName", async (req, res) => {
   const params = req.params;
-  const classID = parseInt(params.classID);
+  const classID = Number(params.classID);
   const storyName = params.storyName;
   const info = await getRosterInfoForStory(classID, storyName);
   res.json(info);
@@ -444,7 +444,7 @@ app.get("/logout", (req, res) => {
 
 app.get("/student/:identifier", async (req, res) => {
   const params = req.params;
-  const id = parseInt(params.identifier);
+  const id = Number(params.identifier);
 
   let student;
   if (isNaN(id)) {
@@ -483,7 +483,7 @@ app.post("/new-dummy-student", async (req, res) => {
 });
 
 app.get("/class-for-student-story/:studentID/:storyName", async (req, res) => {
-  const studentID = parseInt(req.params.studentID);
+  const studentID = Number(req.params.studentID);
   const storyName = req.params.storyName;
   const cls = isNaN(studentID) ? null : await classForStudentStory(studentID, storyName);
   const size = cls != null ? await classSize(cls.id) : 0;
@@ -497,7 +497,7 @@ app.get("/class-for-student-story/:studentID/:storyName", async (req, res) => {
 });
 
 app.get("/options/:studentID", async (req, res) => {
-  const studentID = parseInt(req.params.studentID);
+  const studentID = Number(req.params.studentID);
   const options = await getStudentOptions(studentID);
   res.json(options);
   if (options == null) {
@@ -506,7 +506,7 @@ app.get("/options/:studentID", async (req, res) => {
 });
 
 app.put("/options/:studentID", async (req, res) => {
-  const studentID = parseInt(req.params.studentID);
+  const studentID = Number(req.params.studentID);
   const option = req.body.option;
   const value = req.body.value;
   if (!isStudentOption(option)) {

--- a/src/sql/create_student_table.sql
+++ b/src/sql/create_student_table.sql
@@ -3,7 +3,7 @@ CREATE TABLE Students (
     verified tinyint(2) NOT NULL DEFAULT 0,
     email varchar(50) COLLATE utf8_unicode_ci NOT NULL UNIQUE,
     verification_code varchar(50) COLLATE utf8_unicode_ci NOT NULL UNIQUE,
-    username varchar(50) COLLATE utf8_unicode_ci NOT NULL UNIQUE,
+    username varchar(64) COLLATE utf8_unicode_ci NOT NULL UNIQUE,
     password varchar(64) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
     institution varchar(100) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
     age int(5),


### PR DESCRIPTION
This PR fixes an issue that is arising when our (now randomly-generated) usernames start with at least one digit. Since we're using `parseInt` to parse the identifier, these usernames will return an integer and thus be interpreted as IDs. This PR switches things to what I should've done originally, which is to use `Number` instead.

Additionally, this updates the size of the username in the student table SQL schema, which we updated to account for these randomly-generated names.