### PR TITLE
Add timestamp filtering for Hubble all-data endpoint

### DIFF
--- a/src/stories/hubbles_law/models/hubble_class_data.ts
+++ b/src/stories/hubbles_law/models/hubble_class_data.ts
@@ -7,6 +7,7 @@ export class HubbleClassData extends Model<InferAttributes<HubbleClassData>, Inf
   declare hubble_fit_unit: string;
   declare age_value: number;
   declare age_unit: string;
+  declare last_data_update: Date;
 }
 
 export function initializeHubbleClassDataModel(sequelize: Sequelize) {
@@ -35,6 +36,10 @@ export function initializeHubbleClassDataModel(sequelize: Sequelize) {
     age_unit: {
       type: DataTypes.STRING,
       allowNull: true
+    },
+    last_data_update: {
+      type: DataTypes.DATE,
+      allowNull: false
     }
   }, {
     sequelize,

--- a/src/stories/hubbles_law/models/hubble_student_data.ts
+++ b/src/stories/hubbles_law/models/hubble_student_data.ts
@@ -7,6 +7,7 @@ export class HubbleStudentData extends Model<InferAttributes<HubbleStudentData>,
   declare hubble_fit_unit: string;
   declare age_value: number;
   declare age_unit: string;
+  declare last_data_update: Date;
 }
 
 export function initializeHubbleStudentDataModel(sequelize: Sequelize) {
@@ -35,6 +36,10 @@ export function initializeHubbleStudentDataModel(sequelize: Sequelize) {
     age_unit: {
       type: DataTypes.STRING,
       allowNull: true
+    },
+    last_data_update: {
+      type: DataTypes.DATE,
+      allowNull: false
     }
   }, {
     sequelize,

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -288,10 +288,12 @@ router.get("/stage-3-data/:studentID", async (req, res) => {
   });
 });
 
-router.get("/all-data", async (_req, res) => {
+router.get("/all-data", async (req, res) => {
+  const beforeMs: number = parseInt(req.query.before as string);
+  const before = isNaN(beforeMs) ? null : new Date(beforeMs);
   const [measurements, studentData, classData] =
     await Promise.all([
-      getAllHubbleMeasurements(),
+      getAllHubbleMeasurements(before),
       getAllHubbleStudentData(),
       getAllHubbleClassData()
     ]);

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -294,8 +294,8 @@ router.get("/all-data", async (req, res) => {
   const [measurements, studentData, classData] =
     await Promise.all([
       getAllHubbleMeasurements(before),
-      getAllHubbleStudentData(),
-      getAllHubbleClassData()
+      getAllHubbleStudentData(before),
+      getAllHubbleClassData(before)
     ]);
   res.json({
     measurements,

--- a/src/stories/hubbles_law/sql/create_hubble_class_data_table.sql
+++ b/src/stories/hubbles_law/sql/create_hubble_class_data_table.sql
@@ -4,6 +4,7 @@ CREATE TABLE HubbleClassData (
     hubble_fit_unit varchar(20),
     age_value FLOAT,
     age_unit varchar(20),
+    last_data_update TIMESTAMP NOT NULL,
 
     PRIMARY KEY(class_id),
     FOREIGN KEY(class_id)

--- a/src/stories/hubbles_law/sql/create_hubble_student_data_table.sql
+++ b/src/stories/hubbles_law/sql/create_hubble_student_data_table.sql
@@ -4,6 +4,7 @@ CREATE TABLE HubbleStudentData (
     hubble_fit_unit varchar(20),
     age_value FLOAT,
     age_unit varchar(20),
+    last_data_update TIMESTAMP NOT NULL,
 
     PRIMARY KEY(student_id),
     FOREIGN KEY(student_id)


### PR DESCRIPTION
This PR adds the ability to submit a timestamp (as milliseconds UTC time) for the `/hubbles_law/all-data` endpoint as a query parameter. If specified, only data from before the timestamp will be returned. This is the first step towards resolving https://github.com/cosmicds/hubbleds/issues/284.

To make this possible, a new column `last_data_update` was added to both the student and class summary tables. In each case, the value of this timestamp is the latest value of a `last_modified` timestamp for one of the measurements of that student/class. The SQL table definitions and Sequelize models have been updated accordingly.