### PR TITLE
Use student's story state to filter their class data

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,10 +18,10 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "@typescript-esline/ban-ts-comment": [
+        "@typescript-eslint/ban-ts-comment": [
           "error",
           {
-            "ts-ignore": "allow-with-description",
+            "ts-ignore": "allow-with-description"
           }
         ],
         "@typescript-eslint/no-namespace": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,12 @@
         "@typescript-eslint"
     ],
     "rules": {
+        "@typescript-esline/ban-ts-comment": [
+          "error",
+          {
+            "ts-ignore": "allow-with-description",
+          }
+        ],
         "@typescript-eslint/no-namespace": "off",
         "@typescript-eslint/no-unused-vars": [
           "warn", {

--- a/src/models/student_options.ts
+++ b/src/models/student_options.ts
@@ -11,10 +11,10 @@ export class StudentOptions extends Model<InferAttributes<StudentOptions>, Infer
 
 // TODO: Can we generate this automatically from the class definition?
 const STUDENT_OPTIONS = ["speech_autoread", "speech_rate", "speech_pitch", "speech_voice"] as const;
-export type StudentOption = (typeof STUDENT_OPTIONS)[number];
+export type StudentOption = typeof STUDENT_OPTIONS[number];
 
-export function isStudentOption(o: any): o is StudentOption {
-  return typeof o === "string" && ([...STUDENT_OPTIONS] as string[]).includes(o);
+export function isStudentOption(o: string): o is StudentOption {
+  return typeof o === "string" && (STUDENT_OPTIONS as readonly string[]).includes(o);
 }
 
 export function initializeStudentOptionsModel(sequelize: Sequelize) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,7 +46,6 @@ import sequelizeStore from "connect-session-sequelize";
 import { v4 } from "uuid";
 import cors from "cors";
 import jwt from "jsonwebtoken";
-import { logger } from "./logger";
 import { isStudentOption } from "./models/student_options";
 export const app = express();
 

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -323,8 +323,8 @@ export async function getClassDataIDsForStudent(studentID: number): Promise<numb
       [fn("JSON_EXTRACT", col("story_state"), literal("'$.class_data_students'")), "class_data_students"]
     ]
   }));
-  // TODO: What's the right way to do this?
-  // @ts-ignore
+  // TODO: Remove the need for ts-ignore here
+  // @ts-ignore: Not sure how to add AS-ed in fields to type of the output
   return state.getDataValue("class_data_students");
 }
 

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -1,9 +1,9 @@
-import { Op, Sequelize, WhereOptions } from "sequelize";
+import { Op, Sequelize, WhereOptions, col, fn, literal } from "sequelize";
 import { AsyncMergedHubbleStudentClasses, Galaxy, HubbleMeasurement, SampleHubbleMeasurement, initializeModels, SyncMergedHubbleClasses } from "./models";
 import { cosmicdsDB, findClassById, findStudentById } from "../../database";
 import { RemoveHubbleMeasurementResult, SubmitHubbleMeasurementResult } from "./request_results";
 import { setUpHubbleAssociations } from "./associations";
-import { Class, Student, StudentsClasses } from "../../models";
+import { Class, StoryState, Student, StudentsClasses } from "../../models";
 import { HubbleStudentData } from "./models/hubble_student_data";
 import { HubbleClassData } from "./models/hubble_class_data";
 import { IgnoreStudent } from "../../models/ignore_student";
@@ -212,7 +212,18 @@ export async function getStudentHubbleMeasurements(studentID: number): Promise<H
   });
 }
 
-async function getHubbleMeasurementsForClasses(classIDs: number[]): Promise<HubbleMeasurement[]> {
+async function getHubbleMeasurementsForStudentClasses(studentID: number, classIDs: number[]): Promise<HubbleMeasurement[]> {
+
+  const studentWhereConditions: WhereOptions = [];
+  const classDataStudentIDs = await getClassDataIDsForStudent(studentID);
+  if (classDataStudentIDs.length > 0) {
+    classDataStudentIDs.push(studentID);
+    studentWhereConditions.push({
+      id: {
+        [Op.in]: classDataStudentIDs
+      }
+    });
+  }
 
   return HubbleMeasurement.findAll({
     include: [{
@@ -220,6 +231,7 @@ async function getHubbleMeasurementsForClasses(classIDs: number[]): Promise<Hubb
       attributes: ["id"],
       as: "student",
       required: true,
+      where: studentWhereConditions,
       include: [{
         model: Class,
         attributes: ["id"],
@@ -304,14 +316,26 @@ async function getClassIDsForSyncClass(classID: number): Promise<number[]> {
   return classIDs;
 }
 
-async function getHubbleMeasurementsForSyncClass(classID: number): Promise<HubbleMeasurement[] | null> {
+export async function getClassDataIDsForStudent(studentID: number): Promise<number[]> {
+  const state = (await StoryState.findOne({
+    where: { student_id: studentID },
+    attributes: [
+      [fn("JSON_EXTRACT", col("story_state"), literal("'$.class_data_students'")), "class_data_students"]
+    ]
+  }));
+  // TODO: What's the right way to do this?
+  // @ts-ignore
+  return state.getDataValue("class_data_students");
+}
+
+async function getHubbleMeasurementsForSyncStudent(studentID: number, classID: number): Promise<HubbleMeasurement[] | null> {
   const classIDs = await getClassIDsForSyncClass(classID);
-  return getHubbleMeasurementsForClasses(classIDs);
+  return getHubbleMeasurementsForStudentClasses(studentID, classIDs);
 }
 
 async function getHubbleMeasurementsForAsyncStudent(studentID: number, classID: number | null): Promise<HubbleMeasurement[] | null> {
   const classIDs = await getClassIDsForAsyncStudent(studentID, classID);
-  return getHubbleMeasurementsForClasses(classIDs);
+  return getHubbleMeasurementsForStudentClasses(studentID, classIDs);
 }
 
 export async function getStageThreeMeasurements(studentID: number, classID: number | null, lastChecked: number | null = null): Promise<HubbleMeasurement[]> {
@@ -321,7 +345,7 @@ export async function getStageThreeMeasurements(studentID: number, classID: numb
   if (classID === null || asyncClass) {
     data = await getHubbleMeasurementsForAsyncStudent(studentID, classID);
   } else {
-    data = await getHubbleMeasurementsForSyncClass(classID);
+    data = await getHubbleMeasurementsForSyncStudent(studentID, classID);
   }
   if (data != null && lastChecked != null) {
     const lastModified = Math.max(...data.map(meas => meas.last_modified.getTime()));

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -325,7 +325,7 @@ export async function getClassDataIDsForStudent(studentID: number): Promise<numb
   }));
   // TODO: Remove the need for ts-ignore here
   // @ts-ignore: Not sure how to add AS-ed in fields to type of the output
-  return state.getDataValue("class_data_students");
+  return state.getDataValue("class_data_students") ?? [];
 }
 
 async function getHubbleMeasurementsForSyncStudent(studentID: number, classID: number): Promise<HubbleMeasurement[] | null> {


### PR DESCRIPTION
As part of the scheme outlined in https://github.com/cosmicds/hubbleds/issues/284#issuecomment-1645759328, when a student reaches stage 5, the data that they received is frozen, and a list is kept in their state of the IDs of other students whose data is used for their class data.

The original plan was to fetch the class data and drop any measurement that we didn't want app-side, but since this server has access to the student's story state, it seems easier to me to just build this filter into the database query. Note that if a student hasn't reached stage 5 yet, their `class_data_students` list in the state will be empty - in that case, we just ignore it.