### PR TITLE
Guard against case where story state is null when filtering class data.

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -325,7 +325,7 @@ export async function getClassDataIDsForStudent(studentID: number): Promise<numb
   }));
   // TODO: Remove the need for ts-ignore here
   // @ts-ignore: Not sure how to add AS-ed in fields to type of the output
-  return state.getDataValue("class_data_students") ?? [];
+  return state?.getDataValue("class_data_students") ?? [];
 }
 
 async function getHubbleMeasurementsForSyncStudent(studentID: number, classID: number): Promise<HubbleMeasurement[] | null> {


### PR DESCRIPTION
In the updates of #76, the `ts-ignore` used to get around the typing issues from `JSON_EXTRACT`-ed column meant that I missed a null guard. This PR fixes that.