### PR TITLE
Add infrastructure for questions

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -611,3 +611,7 @@ export async function findQuestion(tag: string, version?: number): Promise<Quest
 export async function addQuestion(tag: string, text: string, shorthand: string, story_name: string, version?: number): Promise<Question | null> {
   return Question.create({ tag, text, shorthand, story_name, version: version || 1 }).catch((_error) => null);
 }
+
+export async function currentVersionForQuestion(tag: string): Promise<number | null> {
+  return Question.max("version", { where: { tag } });
+}

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,4 +1,4 @@
-import { Model, Op, Sequelize } from "sequelize";
+import { Model, Op, Sequelize, WhereOptions } from "sequelize";
 import dotenv from "dotenv";
 
 import {
@@ -601,8 +601,13 @@ export async function setStudentOption(studentID: number, option: StudentOption,
 }
 
 export async function findQuestion(tag: string, version?: number): Promise<Question | null> {
-  version = version || 1;
-  return Question.findOne({
-    where: { tag, version }
-  });
+  const whereQuery: WhereOptions = { tag };
+  if (version !== undefined) {
+    whereQuery["version"] = version;
+  }
+  return Question.findOne({ where: whereQuery });
+}
+
+export async function addQuestion(tag: string, text: string, shorthand: string, story_name: string, version?: number): Promise<Question | null> {
+  return Question.create({ tag, text, shorthand, story_name, version: version || 1 }).catch((_error) => null);
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -31,6 +31,7 @@ import { User } from "./user";
 import { setUpAssociations } from "./associations";
 import { initializeModels } from "./models";
 import { StudentOption, StudentOptions } from "./models/student_options";
+import { Question } from "./models/question";
 
 type SequelizeError = { parent: { code: string } };
 
@@ -597,4 +598,11 @@ export async function setStudentOption(studentID: number, option: StudentOption,
     options.update({ [option]: value });
   }
   return options;
+}
+
+export async function findQuestion(tag: string, version?: number): Promise<Question | null> {
+  version = version || 1;
+  return Question.findOne({
+    where: { tag, version }
+  });
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -10,6 +10,7 @@ import { StudentsClasses, initializeStudentClassModel } from "./student_class";
 import { Student, initializeStudentModel } from "./student";
 import { Sequelize } from "sequelize/types";
 import { initializeStudentOptionsModel } from "./student_options";
+import { initializeQuestionModel } from "./question";
 
 export {
   Class,
@@ -35,4 +36,5 @@ export function initializeModels(db: Sequelize) {
   initializeStudentClassModel(db);
   initializeStudentOptionsModel(db);
   initializeIgnoreStudentModel(db);
+  initializeQuestionModel(db);
 }

--- a/src/models/question.ts
+++ b/src/models/question.ts
@@ -1,4 +1,4 @@
-import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize/types";
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
 import { Story } from "./story";
 
 export class Question extends Model<InferAttributes<Question>, InferCreationAttributes<Question>> {

--- a/src/models/question.ts
+++ b/src/models/question.ts
@@ -1,0 +1,64 @@
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize/types";
+import { Story } from "./story";
+
+export class Question extends Model<InferAttributes<Question>, InferCreationAttributes<Question>> {
+  declare id: CreationOptional<number>;
+  declare tag: string;
+  declare text: string;
+  declare shorthand: string;
+  declare story_name: string;
+  declare version: CreationOptional<number>;
+  declare created: CreationOptional<Date>;
+}
+
+export function initializeQuestionModel(sequelize: Sequelize) {
+  Question.init({
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      unique: true
+    },
+    tag: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
+    text: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    shorthand: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    story_name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      references: {
+        model: Story,
+        key: "id"
+      }
+    },
+    version: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1
+    },
+    created: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
+    }
+  }, {
+    sequelize,
+    engine: "InnoDB",
+    indexes: [
+      {
+        unique: true,
+        fields: ["tag"]
+      }
+    ]
+  });
+}

--- a/src/models/question.ts
+++ b/src/models/question.ts
@@ -23,7 +23,6 @@ export function initializeQuestionModel(sequelize: Sequelize) {
     tag: {
       type: DataTypes.STRING,
       allowNull: false,
-      unique: true
     },
     text: {
       type: DataTypes.STRING,
@@ -56,7 +55,6 @@ export function initializeQuestionModel(sequelize: Sequelize) {
     engine: "InnoDB",
     indexes: [
       {
-        unique: true,
         fields: ["tag"]
       }
     ]

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import {
   getStudentOptions,
   setStudentOption,
   classSize,
+  findQuestion,
   
 } from "./database";
 
@@ -172,7 +173,7 @@ function _sendLoginCookie(userId: number, res: ExpressResponse): void {
 }
 
 // set port, listen for requests
-const PORT = process.env.PORT || 8081;
+const PORT = process.env.PORT || 8080;
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}.`);
 });
@@ -457,6 +458,35 @@ app.get("/student/:identifier", async (req, res) => {
   }
   res.json({
     student: student
+  });
+});
+
+// Question information
+app.get("/question/:tag", async (req, res) => {
+  const tag = req.params.tag;
+  let version = parseInt(req.query.version as string);
+  let hasVersion = true;
+  if (isNaN(version)) {
+    hasVersion = false;
+    version = 1;
+  }
+  const question = await findQuestion(tag, version);
+  if (question === null) {
+    res.statusCode = 404;
+    let error = "Could not find question with specified ";
+    if (hasVersion) {
+      error += "tag/version combination";
+    } else {
+      error += "tag";
+    }
+    res.json({
+      error
+    });
+    return;
+  }
+
+  res.json({
+    question
   });
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ import {
   classSize,
   findQuestion,
   addQuestion,
+  currentVersionForQuestion,
   
 } from "./database";
 
@@ -467,11 +468,17 @@ app.get("/question/:tag", async (req, res) => {
   const tag = req.params.tag;
   let version = parseInt(req.query.version as string);
   let hasVersion = true;
+  let mightExist = true;
   if (isNaN(version)) {
     hasVersion = false;
-    version = 1;
+    const currentVersion = await currentVersionForQuestion(tag) || 1;
+    if (currentVersion === null) {
+      mightExist = false;
+    } else {
+      version = currentVersion;
+    }
   }
-  const question = await findQuestion(tag, version);
+  const question = mightExist ? await findQuestion(tag, version) : null;
   if (question === null) {
     res.statusCode = 404;
     let error = "Could not find question with specified ";

--- a/src/server.ts
+++ b/src/server.ts
@@ -172,7 +172,7 @@ function _sendLoginCookie(userId: number, res: ExpressResponse): void {
 }
 
 // set port, listen for requests
-const PORT = process.env.PORT || 8080;
+const PORT = process.env.PORT || 8081;
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}.`);
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,7 @@ import {
   setStudentOption,
   classSize,
   findQuestion,
+  addQuestion,
   
 } from "./database";
 
@@ -487,6 +488,42 @@ app.get("/question/:tag", async (req, res) => {
 
   res.json({
     question
+  });
+});
+
+
+app.post("/question/:tag", async (req, res) => {
+
+  const tag = req.params.tag;
+  const text = req.body.text;
+  const shorthand = req.body.shorthand;
+  const story_name = req.body.story_name;
+
+  const valid = typeof tag === "string" &&
+                typeof text === "string" &&
+                typeof shorthand === "string" &&
+                typeof story_name === "string";
+  if (!valid) {
+    res.statusCode = 400;
+    res.json({
+      error: "One of your fields is missing or of the incorrect type"
+    });
+    return;
+  }
+
+  const currentQuestion = await findQuestion(tag);
+  const version = currentQuestion !== null ? currentQuestion.version + 1 : 1;
+  const addedQuestion = await addQuestion(tag, text, shorthand, story_name, version);
+  if (addedQuestion === null) {
+    res.statusCode = 500;
+    res.json({
+      error: "There was an error creating the question entry."
+    });
+    return;
+  }
+
+  res.json({
+    question: addedQuestion
   });
 });
 

--- a/src/sql/create_questions_table.sql
+++ b/src/sql/create_questions_table.sql
@@ -10,7 +10,7 @@ CREATE TABLE Questions (
     PRIMARY KEY(id),
     INDEX(tag),
     FOREIGN KEY(story_name)
-		REFERENCES Stories(name)
+	    REFERENCES Stories(name)
         ON UPDATE CASCADE
         ON DELETE CASCADE
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;

--- a/src/sql/create_questions_table.sql
+++ b/src/sql/create_questions_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE Questions (
 	id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
-    tag varchar(50) NOT NULL UNIQUE,
+    tag varchar(50) NOT NULL,
     text varchar(3000) NOT NULL,
     shorthand varchar(500) NOT NULL,
     story_name varchar(50) NOT NULL,

--- a/src/sql/create_questions_table.sql
+++ b/src/sql/create_questions_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE Questions (
+	id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
+    tag varchar(50) NOT NULL UNIQUE,
+    text varchar(3000) NOT NULL,
+    shorthand varchar(500) NOT NULL,
+    story_name varchar(50) NOT NULL,
+    version int(11) NOT NULL DEFAULT 1,
+    created datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    
+    PRIMARY KEY(id),
+    INDEX(tag),
+    FOREIGN KEY(story_name)
+		REFERENCES Stories(name)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;
+    


### PR DESCRIPTION
This PR creates a model for the newly-added `Questions` table, which contains information about the questions that we ask throughout each story. Additionally, this adds two new endpoints to the server:

- `GET /question/:tag` - returns the information about the question with the given tag (if it exists). Specifying a `version`  query parameter gets information for that particular version. Otherwise, the most recent version (if one exists) is used
- `POST /question/:tag` - creates a new version of this question (version 1 if it didn't previously exist) using the information in the request body. Follows the scheme outlined in https://github.com/cosmicds/cosmicds/issues/260#issue-1837216528