### PR TITLE
Make (tag, story name, version) a unique key

### DIFF
--- a/src/models/question.ts
+++ b/src/models/question.ts
@@ -56,6 +56,11 @@ export function initializeQuestionModel(sequelize: Sequelize) {
     indexes: [
       {
         fields: ["tag"]
+      },
+      {
+        fields: ["tag", "story_name", "version"],
+        name: "unique_tag_story_version",
+        unique: true
       }
     ]
   });

--- a/src/sql/create_questions_table.sql
+++ b/src/sql/create_questions_table.sql
@@ -9,6 +9,7 @@ CREATE TABLE Questions (
     
     PRIMARY KEY(id),
     INDEX(tag),
+    UNIQUE KEY unique_tag_story_version (tag, story_name, version),
     FOREIGN KEY(story_name)
 	    REFERENCES Stories(name)
         ON UPDATE CASCADE


### PR DESCRIPTION
One thing that does make logical sense to enforce in the questions table is that the (tag, story name, version) should be a unique tuple of values - we should never have duplicates of this. I've changed this in the database already, but this PR keeps our schemas up-to-date.