### PR TITLE
Allow adding answers to questions

### DIFF
--- a/src/models/question.ts
+++ b/src/models/question.ts
@@ -9,6 +9,9 @@ export class Question extends Model<InferAttributes<Question>, InferCreationAttr
   declare story_name: string;
   declare version: CreationOptional<number>;
   declare created: CreationOptional<Date>;
+  declare answers_text: CreationOptional<string[]>;
+  declare correct_answers: CreationOptional<number[]>;
+  declare neutral_answers: CreationOptional<number[]>;
 }
 
 export function initializeQuestionModel(sequelize: Sequelize) {
@@ -49,6 +52,18 @@ export function initializeQuestionModel(sequelize: Sequelize) {
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
+    },
+    answers_text: {
+      type: DataTypes.JSON,
+      defaultValue: null
+    },
+    correct_answers: {
+      type: DataTypes.JSON,
+      defaultValue: null
+    },
+    neutral_answers: {
+      type: DataTypes.JSON,
+      defaultValue: null
     }
   }, {
     sequelize,

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,6 +50,7 @@ import { v4 } from "uuid";
 import cors from "cors";
 import jwt from "jsonwebtoken";
 import { isStudentOption } from "./models/student_options";
+import { isNumberArray, isStringArray } from "./utils";
 export const app = express();
 
 // TODO: Clean up these type definitions
@@ -505,11 +506,17 @@ app.post("/question/:tag", async (req, res) => {
   const text = req.body.text;
   const shorthand = req.body.shorthand;
   const story_name = req.body.story_name;
+  const answers_text = req.body.answers_text;
+  const correct_answers = req.body.correct_answers;
+  const neutral_answers = req.body.neutral_answers;
 
   const valid = typeof tag === "string" &&
                 typeof text === "string" &&
                 typeof shorthand === "string" &&
-                typeof story_name === "string";
+                typeof story_name === "string" &&
+                (answers_text === undefined || isStringArray(answers_text)) &&
+                (correct_answers === undefined || isNumberArray(correct_answers)) &&
+                (neutral_answers === undefined || isNumberArray(neutral_answers));
   if (!valid) {
     res.statusCode = 400;
     res.json({
@@ -520,7 +527,7 @@ app.post("/question/:tag", async (req, res) => {
 
   const currentQuestion = await findQuestion(tag);
   const version = currentQuestion !== null ? currentQuestion.version + 1 : 1;
-  const addedQuestion = await addQuestion(tag, text, shorthand, story_name, version);
+  const addedQuestion = await addQuestion({tag, text, shorthand, story_name, answers_text, correct_answers, neutral_answers, version});
   if (addedQuestion === null) {
     res.statusCode = 500;
     res.json({

--- a/src/sql/create_questions_table.sql
+++ b/src/sql/create_questions_table.sql
@@ -6,6 +6,9 @@ CREATE TABLE Questions (
     story_name varchar(50) NOT NULL,
     version int(11) NOT NULL DEFAULT 1,
     created datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    answers_text JSON DEFAULT NULL,
+    correct_answers JSON DEFAULT NULL,
+    neutral_answers JSON DEFAULT NULL,
     
     PRIMARY KEY(id),
     INDEX(tag),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,3 +20,13 @@ export function createClassCode(educatorID: number, className: string) {
   const nameString = `${educatorID}_${className}`;
   return createV5(nameString);
 }
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+export function isNumberArray(arr: any): arr is number[] {
+  return Array.isArray(arr) && arr.every(x => typeof x === "number");
+}
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+export function isStringArray(arr: any): arr is string[] {
+  return Array.isArray(arr) && arr.every(x => typeof x === "string");
+}


### PR DESCRIPTION
This PR updates the question model and associated `POST` endpoint to allow specifying answers to questions (for multiple choices). The new fields that one can specify in the `POST` request have the following structure:

- `answers_text: string[]`
- `correct_answers: number[]`
- `neutral_answers: number[]`

For a free response question these should be omitted from the request body; they will automatically be set to `NULL` in the database.

@johnarban Let me know if you have any questions/issues/etc when using this for the questions analysis.