### PR TITLE
Allow getting all questions for a story

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -639,3 +639,11 @@ export async function addQuestion(info: QuestionInfo): Promise<Question | null> 
 export async function currentVersionForQuestion(tag: string): Promise<number | null> {
   return Question.max("version", { where: { tag } });
 }
+
+export async function getQuestionsForStory(storyName: string): Promise<Question[]> {
+  return Question.findAll({
+    where: {
+      story_name: storyName
+    }
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -544,7 +544,9 @@ app.post("/question/:tag", async (req, res) => {
 
 app.get("/questions/:storyName", async (req, res) => {
   const storyName = req.params.storyName;
-  const questions = await getQuestionsForStory(storyName);
+  const newestOnlyString = req.query.newest_only as string;
+  const newestOnly = newestOnlyString.toLowerCase() !== "false";
+  const questions = await getQuestionsForStory(storyName, newestOnly);
   res.json({
     questions
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,7 +27,7 @@ import {
   findQuestion,
   addQuestion,
   currentVersionForQuestion,
-  
+  getQuestionsForStory,
 } from "./database";
 
 import {
@@ -538,6 +538,15 @@ app.post("/question/:tag", async (req, res) => {
 
   res.json({
     question: addedQuestion
+  });
+});
+
+
+app.get("/questions/:storyName", async (req, res) => {
+  const storyName = req.params.storyName;
+  const questions = await getQuestionsForStory(storyName);
+  res.json({
+    questions
   });
 });
 


### PR DESCRIPTION
This PR adds an endpoint `GET /questions/<story-name>` which will allow getting all questions associated with a given story. By default, only the newest version for each question tag will be returned. If one instead wants all versions of the questions returned, this can be done by using the query `newest_only=false`.

CC @johnarban