### PR TITLE
Only store one response per user for eclipse mini

### DIFF
--- a/src/stories/minids/database.ts
+++ b/src/stories/minids/database.ts
@@ -1,5 +1,11 @@
 import { cosmicdsDB } from "../../database";
 import { logger } from "../../logger";
+import {
+  isArrayThatSatisfies,
+  isNumberArray,
+  isStringArray
+} from "../../utils";
+
 import { initializeModels, EclipseMiniResponse } from "./models";
 
 initializeModels(cosmicdsDB);
@@ -10,6 +16,17 @@ export interface EclipseMiniData {
   preset_locations: string[],
   user_selected_locations: [number, number][],
   timestamp: Date
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isValidEclipseMiniData(data: any): data is EclipseMiniData {
+
+  return typeof data.user_uuid === "string" &&
+    typeof data.response === "string" &&
+    isStringArray(data.preset_locations) &&
+    isArrayThatSatisfies(data.user_selected_locations, (arr) => {
+      return arr.every(x => isNumberArray(x) && x.length === 2);
+    });
 }
 
 export async function submitEclipseMiniResponse(data: EclipseMiniData): Promise<EclipseMiniResponse | null> {

--- a/src/stories/minids/database.ts
+++ b/src/stories/minids/database.ts
@@ -4,29 +4,34 @@ import { initializeModels, EclipseMiniResponse } from "./models";
 
 initializeModels(cosmicdsDB);
 
-export async function submitEclipseMiniResponse(data: {
-  user_uuid: string,
-  response: string,
+export interface EclipseMiniData {
+  user_uuid: string;
+  response: string;
   preset_locations: string[],
   user_selected_locations: [number, number][],
   timestamp: Date
-}): Promise<EclipseMiniResponse | null> {
+}
+
+export async function submitEclipseMiniResponse(data: EclipseMiniData): Promise<EclipseMiniResponse | null> {
 
   logger.verbose(`Attempting to submit measurement for user ${data.user_uuid}`);
 
-  return EclipseMiniResponse.create({ 
+  const dataWithCounts = {
     ...data,
     preset_locations_count: data.preset_locations.length,
     user_selected_locations_count: data.user_selected_locations.length
-  });
+  };
+
+  return EclipseMiniResponse.upsert(dataWithCounts).then(([item, _]) => item);
+
 }
 
 export async function getAllEclipseMiniResponses(): Promise<EclipseMiniResponse[]> {
   return EclipseMiniResponse.findAll();
 }
 
-export async function getEclipseMiniResponses(userUUID: string): Promise<EclipseMiniResponse[]> {
-  return EclipseMiniResponse.findAll({
+export async function getEclipseMiniResponse(userUUID: string): Promise<EclipseMiniResponse | null> {
+  return EclipseMiniResponse.findOne({
     where: { user_uuid: userUUID }
   });
 }

--- a/src/stories/minids/models/eclipse_response.ts
+++ b/src/stories/minids/models/eclipse_response.ts
@@ -21,6 +21,7 @@ export function initializeEclipseMiniResponseModel(sequelize: Sequelize) {
     },
     user_uuid: {
       type: DataTypes.STRING,
+      unique: true,
       allowNull: false
     },
     response: {

--- a/src/stories/minids/router.ts
+++ b/src/stories/minids/router.ts
@@ -1,24 +1,16 @@
-import {
-  isArrayThatSatisfies,
-  isNumberArray,
-  isStringArray
-} from "../../utils";
-
 import { Router } from "express";
-import { getEclipseMiniResponse, getAllEclipseMiniResponses, submitEclipseMiniResponse } from "./database";
+import {
+  getEclipseMiniResponse,
+  getAllEclipseMiniResponses,
+  isValidEclipseMiniData,
+  submitEclipseMiniResponse
+} from "./database";
 
 const router = Router();
 
 router.put("/annular-eclipse-2023/response", async (req, res) => {
   const data = req.body; 
-  const valid = (
-    typeof data.user_uuid === "string" &&
-    typeof data.response === "string" &&
-    isStringArray(data.preset_locations) &&
-    isArrayThatSatisfies(data.user_selected_locations, (arr) => {
-      return arr.every(x => isNumberArray(x) && x.length === 2);
-    })
-  );
+  const valid = isValidEclipseMiniData(data);
 
   if (!valid) {
     res.status(400);

--- a/src/stories/minids/router.ts
+++ b/src/stories/minids/router.ts
@@ -5,11 +5,11 @@ import {
 } from "../../utils";
 
 import { Router } from "express";
-import { getEclipseMiniResponses, getAllEclipseMiniResponses, submitEclipseMiniResponse } from "./database";
+import { getEclipseMiniResponse, getAllEclipseMiniResponses, submitEclipseMiniResponse } from "./database";
 
 const router = Router();
 
-router.post("/annular-eclipse-2023/response", async (req, res) => {
+router.put("/annular-eclipse-2023/response", async (req, res) => {
   const data = req.body; 
   const valid = (
     typeof data.user_uuid === "string" &&
@@ -42,10 +42,10 @@ router.get("/annular-eclipse-2023/responses", async (_req, res) => {
   res.json({ responses });
 });
 
-router.get("/annular-eclipse-2023/responses/:userUUID", async (req, res) => {
+router.get("/annular-eclipse-2023/response/:userUUID", async (req, res) => {
   const uuid = req.params.userUUID as string;
-  const responses = await getEclipseMiniResponses(uuid);
-  res.json({ responses });
+  const response = await getEclipseMiniResponse(uuid);
+  res.json({ response });
 });
 
 export default router;

--- a/src/stories/minids/sql/create_eclipse_response_table.sql
+++ b/src/stories/minids/sql/create_eclipse_response_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE EclipseMiniResponses (
 	id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
-	user_uuid varchar(36) NOT NULL,
+	user_uuid varchar(36) NOT NULL UNIQUE,
     response char(1) NOT NULL,
     preset_locations JSON NOT NULL,
     preset_locations_count INT NOT NULL,


### PR DESCRIPTION
We now only want to store one entry per user (identified by `user_uuid`) in the table of eclipse mini responses.