### PR TITLE
Allow eclipse mini response to be null

### DIFF
--- a/src/stories/minids/database.ts
+++ b/src/stories/minids/database.ts
@@ -22,7 +22,7 @@ export interface EclipseMiniData {
 export function isValidEclipseMiniData(data: any): data is EclipseMiniData {
 
   return typeof data.user_uuid === "string" &&
-    typeof data.response === "string" &&
+    (!data.response || typeof data.response === "string") &&
     isStringArray(data.preset_locations) &&
     isArrayThatSatisfies(data.user_selected_locations, (arr) => {
       return arr.every(x => isNumberArray(x) && x.length === 2);

--- a/src/stories/minids/models/eclipse_response.ts
+++ b/src/stories/minids/models/eclipse_response.ts
@@ -26,7 +26,7 @@ export function initializeEclipseMiniResponseModel(sequelize: Sequelize) {
     },
     response: {
       type: DataTypes.CHAR,
-      allowNull: false
+      defaultValue: null
     },
     preset_locations: {
       type: DataTypes.JSON,

--- a/src/stories/minids/sql/create_eclipse_response_table.sql
+++ b/src/stories/minids/sql/create_eclipse_response_table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE EclipseMiniResponses (
 	id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
 	user_uuid varchar(36) NOT NULL UNIQUE,
-    response char(1) NOT NULL,
+    response char(1) DEFAULT NULL,
     preset_locations JSON NOT NULL,
     preset_locations_count INT NOT NULL,
     user_selected_locations JSON NOT NULL,


### PR DESCRIPTION
Since we're now going to potentially be sending eclipse mini data before a user has answered the multiple choice question, we need to allow the MC response to be null.