### PR TITLE
Store list of MC responses for eclipse mini

### DIFF
--- a/src/stories/minids/database.ts
+++ b/src/stories/minids/database.ts
@@ -12,7 +12,7 @@ initializeModels(cosmicdsDB);
 
 export interface EclipseMiniData {
   user_uuid: string;
-  response: string;
+  mc_responses: string[];
   preset_locations: string[],
   user_selected_locations: [number, number][],
   timestamp: Date
@@ -22,7 +22,7 @@ export interface EclipseMiniData {
 export function isValidEclipseMiniData(data: any): data is EclipseMiniData {
 
   return typeof data.user_uuid === "string" &&
-    (!data.response || typeof data.response === "string") &&
+    (!data.mc_responses || isStringArray(data.mc_responses)) &&
     isStringArray(data.preset_locations) &&
     isArrayThatSatisfies(data.user_selected_locations, (arr) => {
       return arr.every(x => isNumberArray(x) && x.length === 2);

--- a/src/stories/minids/models/eclipse_response.ts
+++ b/src/stories/minids/models/eclipse_response.ts
@@ -3,7 +3,7 @@ import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, 
 export class EclipseMiniResponse extends Model<InferAttributes<EclipseMiniResponse>, InferCreationAttributes<EclipseMiniResponse>> {
   declare id: CreationOptional<number>;
   declare user_uuid: string;
-  declare response: string;
+  declare mc_responses: string[];
   declare preset_locations: string[];
   declare preset_locations_count: number;
   declare user_selected_locations: [number, number][];
@@ -24,8 +24,8 @@ export function initializeEclipseMiniResponseModel(sequelize: Sequelize) {
       unique: true,
       allowNull: false
     },
-    response: {
-      type: DataTypes.CHAR,
+    mc_responses: {
+      type: DataTypes.JSON,
       defaultValue: null
     },
     preset_locations: {

--- a/src/stories/minids/sql/create_eclipse_response_table.sql
+++ b/src/stories/minids/sql/create_eclipse_response_table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE EclipseMiniResponses (
 	id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
 	user_uuid varchar(36) NOT NULL UNIQUE,
-    response char(1) DEFAULT NULL,
+    responses JSON DEFAULT NULL,
     preset_locations JSON NOT NULL,
     preset_locations_count INT NOT NULL,
     user_selected_locations JSON NOT NULL,

--- a/src/stories/minids/sql/create_eclipse_response_table.sql
+++ b/src/stories/minids/sql/create_eclipse_response_table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE EclipseMiniResponses (
 	id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
 	user_uuid varchar(36) NOT NULL UNIQUE,
-    responses JSON DEFAULT NULL,
+    mc_responses JSON DEFAULT NULL,
     preset_locations JSON NOT NULL,
     preset_locations_count INT NOT NULL,
     user_selected_locations JSON NOT NULL,


### PR DESCRIPTION
This PR changes the eclipse mini storage from having one single response (when we imagined each entry as corresponding to a single event) to being a list of responses, which makes more sense with the one-entry-per-user model that we're using now.