### PR TITLE
Dashboard class groups

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -9,13 +9,15 @@ import {
   Story,
   StudentsClasses,
   Student,
-  DummyClass
+  DummyClass,
+  DashboardClassGroup,
 } from "./models";
 
 import {
   createClassCode,
   createVerificationCode,
   encryptPassword,
+  isNumberArray,
 } from "./utils";
 
 
@@ -660,4 +662,14 @@ export async function getQuestionsForStory(storyName: string, newestOnly=true): 
                            model: Question,
                            type: QueryTypes.SELECT
                          });
+}
+
+
+export async function getDashboardGroupClasses(code: string): Promise<number[]> {
+  const group = await DashboardClassGroup.findOne({ where: { code } });
+  if (group === null) {
+    return [];
+  }
+  const classIDs = group.class_ids;
+  return isNumberArray(classIDs) ? classIDs : [];
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -665,10 +665,10 @@ export async function getQuestionsForStory(storyName: string, newestOnly=true): 
 }
 
 
-export async function getDashboardGroupClasses(code: string): Promise<number[]> {
+export async function getDashboardGroupClasses(code: string): Promise<number[] | null> {
   const group = await DashboardClassGroup.findOne({ where: { code } });
   if (group === null) {
-    return [];
+    return null;
   }
   const classIDs = group.class_ids;
   return isNumberArray(classIDs) ? classIDs : [];

--- a/src/models/dashboard_class_group.ts
+++ b/src/models/dashboard_class_group.ts
@@ -1,0 +1,36 @@
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional, DATE } from "sequelize";
+
+export class DashboardClassGroup extends Model<InferAttributes<DashboardClassGroup>, InferCreationAttributes<DashboardClassGroup>> {
+  declare id: CreationOptional<number>;
+  declare name: string;
+  declare code: string;
+  declare class_ids: number[];
+}
+
+export function initializeDashboardClassGroupModel(sequelize: Sequelize) {
+  DashboardClassGroup.init({
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
+    code: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
+    class_ids: {
+      type: DataTypes.JSON,
+      allowNull: false
+    }
+  }, {
+    sequelize,
+    engine: "InnoDB"
+  });
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,4 +1,5 @@
 import { Class, initializeClassModel } from "./class";
+import { DashboardClassGroup, initializeDashboardClassGroupModel } from "./dashboard_class_group";
 import { DummyClass, initializeDummyClassModel } from "./dummy_class";
 import { Educator, initializeEducatorModel } from "./educator";
 import { IgnoreStudent, initializeIgnoreStudentModel } from "./ignore_student";
@@ -17,6 +18,7 @@ export {
   Class,
   ClassStories,
   CosmicDSSession,
+  DashboardClassGroup,
   DummyClass,
   Educator,
   IgnoreStudent,
@@ -39,4 +41,5 @@ export function initializeModels(db: Sequelize) {
   initializeStudentOptionsModel(db);
   initializeIgnoreStudentModel(db);
   initializeQuestionModel(db);
+  initializeDashboardClassGroupModel(db);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -656,8 +656,14 @@ app.put("/options/:studentID", async (req, res) => {
 
 app.get("/dashboard-group-classes/:code", async (req, res) => {
   const classIDs = await getDashboardGroupClasses(req.params.code);
-  res.statusCode = classIDs.length > 0 ? 200 : 404;
-  res.json({
-    class_ids: classIDs
-  });
+  if (classIDs === null) {
+    res.statusCode = 404;
+    res.json({
+      error: `Could not find a dashboard group for code ${req.params.code}`
+    });
+  } else {
+    res.json({
+      class_ids: classIDs
+    });
+  }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import {
   addQuestion,
   currentVersionForQuestion,
   getQuestionsForStory,
+  getDashboardGroupClasses,
 } from "./database";
 
 import { getAPIKey, hasPermission } from "./authorization";
@@ -651,4 +652,12 @@ app.put("/options/:studentID", async (req, res) => {
     return;
   }
   res.json(updatedOptions);
+});
+
+app.get("/dashboard-group-classes/:code", async (req, res) => {
+  const classIDs = await getDashboardGroupClasses(req.params.code);
+  res.statusCode = classIDs.length > 0 ? 200 : 404;
+  res.json({
+    class_ids: classIDs
+  });
 });

--- a/src/sql/create_dashboard_class_group_table.sql
+++ b/src/sql/create_dashboard_class_group_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE DashboardClassGroups (
+	id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
+    name varchar(50) UNIQUE NOT NULL,
+    code varchar(36) UNIQUE NOT NULL,
+    class_ids JSON NOT NULL,
+    
+    PRIMARY KEY(id)
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;


### PR DESCRIPTION
This PR adds the SQL and model for a table describing dashboard class groups. Since I don't imagine this will be a long-term thing, I didn't want to create a junction table as well, so the associated class IDs for a group are just stored as a list of integers in MySQL's `JSON` format.

Additionally, this adds an endpoint `/dashboard-class-groups<code>`, which will return an object whose `class_ids` field is list of class IDs associated with the class group corresponding to the given code. If the code isn't found, the response code is a 404 and the response will just contain an error message.