### PR TITLE
Modify dashboard group classes endpoint to return class data

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -665,11 +665,21 @@ export async function getQuestionsForStory(storyName: string, newestOnly=true): 
 }
 
 
-export async function getDashboardGroupClasses(code: string): Promise<number[] | null> {
+export async function getDashboardGroupClasses(code: string): Promise<Class[] | null> {
   const group = await DashboardClassGroup.findOne({ where: { code } });
   if (group === null) {
     return null;
   }
   const classIDs = group.class_ids;
-  return isNumberArray(classIDs) ? classIDs : [];
+  if (!isNumberArray(classIDs)) {
+    return [];
+  }
+  return Class.findAll({
+    where: {
+      id: {
+        [Op.in]: classIDs
+      }
+    }
+  });
+
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -663,7 +663,7 @@ app.get("/dashboard-group-classes/:code", async (req, res) => {
     });
   } else {
     res.json({
-      class_ids: classIDs
+      classes: classIDs
     });
   }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -655,15 +655,15 @@ app.put("/options/:studentID", async (req, res) => {
 });
 
 app.get("/dashboard-group-classes/:code", async (req, res) => {
-  const classIDs = await getDashboardGroupClasses(req.params.code);
-  if (classIDs === null) {
+  const classes= await getDashboardGroupClasses(req.params.code);
+  if (classes === null) {
     res.statusCode = 404;
     res.json({
       error: `Could not find a dashboard group for code ${req.params.code}`
     });
   } else {
     res.json({
-      classes: classIDs
+      classes
     });
   }
 });


### PR DESCRIPTION
This PR updates the `/dashboard-group-classes` endpoint introduced in #93 to return the data for each class, rather than just its ID.

The new format of a successful request will be
```
{
    classes: [<class_1_data>, <class_2_data>]
}
```

where each class data object will have the `id` and `name`, etc.

CC @johnarban