### PR TITLE
Add endpoint for creating synchronous class merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/src/database.ts
+++ b/src/database.ts
@@ -664,7 +664,6 @@ export async function getQuestionsForStory(storyName: string, newestOnly=true): 
                          });
 }
 
-
 export async function getDashboardGroupClasses(code: string): Promise<Class[] | null> {
   const group = await DashboardClassGroup.findOne({ where: { code } });
   if (group === null) {

--- a/src/models/class.ts
+++ b/src/models/class.ts
@@ -10,6 +10,7 @@ export class Class extends Model<InferAttributes<Class>, InferCreationAttributes
   declare active: CreationOptional<boolean>;
   declare code: string;
   declare asynchronous: CreationOptional<boolean>;
+  declare test: CreationOptional<boolean>;
 }
 
 export function initializeClassModel(sequelize: Sequelize) {
@@ -55,6 +56,11 @@ export function initializeClassModel(sequelize: Sequelize) {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false
+    },
+    test: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: 0
     }
   }, {
     sequelize,

--- a/src/sql/create_class_table.sql
+++ b/src/sql/create_class_table.sql
@@ -6,6 +6,7 @@ CREATE TABLE Classes (
     active tinyint(1) NOT NULL DEFAULT 0,
     code varchar(50) NOT NULL UNIQUE,
     asynchronous tinyint(1) NOT NULL DEFAULT 0,
+    test tinyint(1) NOT NULL DEFAULT 0,
     updated datetime DEFAULT NULL,
  
     PRIMARY KEY(id),

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -31,7 +31,8 @@ import {
   getSampleGalaxy,
   getGalaxyById,
   removeSampleHubbleMeasurement,
-  getAllNthSampleHubbleMeasurements
+  getAllNthSampleHubbleMeasurements,
+  tryToMergeClass
 } from "./database";
 
 import { 
@@ -322,6 +323,30 @@ router.get("/all-data", async (req, res) => {
     measurements,
     studentData,
     classData
+  });
+});
+
+router.put("/sync-merged-class/:classID", async(req, res) => {
+  const classID = parseInt(req.params.classID);
+  if (isNaN(classID)) {
+    res.statusCode = 400;
+    res.json({
+      error: "Class ID must be a number"
+    });
+    return;
+  }
+  const data = await tryToMergeClass(classID);
+  if (data.mergeData === null) {
+    res.statusCode = 404;
+    res.json({
+      error: data.message
+    });
+    return;
+  }
+
+  res.json({
+    merge_info: data.mergeData,
+    message: data.message
   });
 });
 


### PR DESCRIPTION
This PR makes progress on https://github.com/cosmicds/hubbleds/issues/319 by adding an endpoint that allows us to request a synchronous class merge. If one already exists, no action is taken and the existing merge info is returned.

This doesn't handle asynchronous classes, which are a bit more complicated but should be able to build off of this.