### PR TITLE
Fix issue with students in multiple classes

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -386,6 +386,7 @@ export async function getAllHubbleMeasurements(before: Date | null = null): Prom
     whereConditions.push({ last_modified: { [Op.lt]: before } });
   }
   return HubbleMeasurement.findAll({
+    raw: true,
     attributes: {
       // The "student" here comes from the alias below
       // We do this so that we get access to the included field as just "class_id"
@@ -397,11 +398,11 @@ export async function getAllHubbleMeasurements(before: Date | null = null): Prom
     include: [{
       model: Galaxy,
       as: "galaxy",
-      attributes: ["id", "type"]
+      attributes: []
     }, {
       model: Student,
       as: "student",
-      attributes: ["seed", "dummy"],
+      attributes: [],
       where: {
         [Op.or]: [
           { seed: 1 }, { dummy: 0 }


### PR DESCRIPTION
This PR fixes an issue where if a student is in multiple classes, their measurements only show up in one of those classes when queried via `/hubbles_law/all-data`.