### PR TITLE
Cache valid API keys

### DIFF
--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -4,11 +4,20 @@ import { APIKey } from "./models/api_key";
 
 const HASHER = new SHA3(256);
 
+const validKeys = new Map<string, APIKey>();
+
 export async function getAPIKey(key: string): Promise<APIKey | null> {
+  const cachedKey = validKeys.get(key);
+  if (cachedKey !== undefined) {
+    return cachedKey;
+  }
   HASHER.update(key);
   const hashedKey = HASHER.digest("hex");
   const apiKey = await APIKey.findOne({ where: { hashed_key: hashedKey } });
   HASHER.reset();
+  if (apiKey !== null) {
+    validKeys.set(key, apiKey);
+  }
   return apiKey;
 }
 


### PR DESCRIPTION
This PR adds a map of API keys that the server has found to be valid and stores them locally. This gives us the benefit of improved performance (no need for a database query) while still allowing the database to be persistent storage. If the server is reset/a new server is spun up, it can just build up the cache as it gets requests.

A few notes:
* Our total number of unique API keys is small, so this shouldn't use much space in memory.
* This doesn't do anything with invalid API keys. I guess there's no reason that we couldn't, but I don't really expect this to be a concern - we're more likely to get requests that don't have a key. Also, there's always the (very) slim chance that we add a new API key that clashes with something that has already been marked bad.
* This does mean that updates to an already-used API key (e.g. permissions) would require a server restart. We basically never change these, but it's worth noting in case this ever happens.