### PR TITLE
Allow institution to be nullable

### DIFF
--- a/src/sql/create_student_table.sql
+++ b/src/sql/create_student_table.sql
@@ -5,7 +5,7 @@ CREATE TABLE Students (
     verification_code varchar(50) COLLATE utf8_unicode_ci NOT NULL UNIQUE,
     username varchar(64) COLLATE utf8_unicode_ci NOT NULL UNIQUE,
     password varchar(64) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-    institution varchar(100) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+    institution varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
     age int(5),
     gender varchar(20) COLLATE utf8_unicode_ci,
     ip varchar(50) COLLATE utf8_unicode_ci,


### PR DESCRIPTION
There's currently a mismatch between the runtime validation and the `Students` table schema - in the TS we expect `institution` to be nullable, but that wasn't the case. I've updated the schema of the table; this PR just keeps our SQL definition file up to date.