### PR TITLE
Add query option for galaxy flags

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -1,4 +1,4 @@
-import { Op, QueryTypes, Sequelize, WhereOptions, col, fn, literal } from "sequelize";
+import { Attributes, FindOptions, Op, QueryTypes, Sequelize, WhereOptions, col, fn, literal } from "sequelize";
 import { AsyncMergedHubbleStudentClasses, Galaxy, HubbleMeasurement, SampleHubbleMeasurement, initializeModels, SyncMergedHubbleClasses } from "./models";
 import { classSize, cosmicdsDB, findClassById, findStudentById } from "../../database";
 import { RemoveHubbleMeasurementResult, SubmitHubbleMeasurementResult } from "./request_results";
@@ -12,7 +12,7 @@ import { logger } from "../../logger";
 initializeModels(cosmicdsDB);
 setUpHubbleAssociations();
 
-const galaxyAttributes = ["ra", "decl", "z", "type", "name", "element"];
+const galaxyAttributes = ["id", "ra", "decl", "z", "type", "name", "element"];
 
 export async function submitHubbleMeasurement(data: {
   student_id: number,
@@ -506,25 +506,37 @@ export async function removeSampleHubbleMeasurement(studentID: number, measureme
   return count > 0 ? RemoveHubbleMeasurementResult.MeasurementDeleted : RemoveHubbleMeasurementResult.NoSuchMeasurement;
 }
 
-export async function getGalaxiesForTypes(types: string[]): Promise<Galaxy[]> {
-  return Galaxy.findAll({
+export async function getGalaxiesForTypes(types: string[], flags=false): Promise<Galaxy[]> {
+  const query: FindOptions<Attributes<Galaxy>> = {
     where: {
       is_bad: 0,
       spec_is_bad: 0,
       is_sample: 0,
       type: { [Op.in]: types }
     }
-  });
+  };
+
+  if (!flags) {
+    query.attributes = galaxyAttributes;
+  }
+
+  return Galaxy.findAll(query);
 }
 
-export async function getAllGalaxies(): Promise<Galaxy[]> {
-  return Galaxy.findAll({
+export async function getAllGalaxies(flags=false): Promise<Galaxy[]> {
+  const query: FindOptions<Attributes<Galaxy>> = {
     where: {
       is_bad: 0,
       spec_is_bad: 0,
       is_sample: 0
     }
-  });
+  };
+
+  if (!flags) {
+    query.attributes = galaxyAttributes;
+  }
+
+  return Galaxy.findAll(query);
 }
 
 export async function getGalaxyByName(name: string): Promise<Galaxy | null> {

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -352,9 +352,10 @@ router.put("/sync-merged-class/:classID", async(req, res) => {
 
 router.get("/galaxies", async (req, res) => {
   const types = req.query?.types ?? undefined;
+  const flags = (/true/i).test((req.query?.flags as string) ?? undefined);
   let galaxies: Galaxy[];
   if (types === undefined) {
-    galaxies = await getAllGalaxies();
+    galaxies = await getAllGalaxies(flags);
   } else {
     let galaxyTypes: string[];
     if (Array.isArray(types)) {
@@ -362,7 +363,7 @@ router.get("/galaxies", async (req, res) => {
     } else {
       galaxyTypes = (types as string).split(",");
     }
-    galaxies = await getGalaxiesForTypes(galaxyTypes);
+    galaxies = await getGalaxiesForTypes(galaxyTypes, flags);
   }
   res.json(galaxies);
 });


### PR DESCRIPTION
While we want to store some flags for galaxies in the database (have they/their spectra been marked bad or checked), we don't really need to give this to the app when fetching galaxy data. This PR hides these flags unless a `flags=true` query is included in the galaxy endpoint. This reduces the galaxy data sent to the app on first load from ~195kb to ~91kb.