### PR TITLE
Remove 'get all' endpoint for solar eclipse.

### DIFF
--- a/src/stories/solar-eclipse-2024/router.ts
+++ b/src/stories/solar-eclipse-2024/router.ts
@@ -32,11 +32,6 @@ router.put("/data", async (req, res) => {
   res.json({ response });
 });
 
-router.get("/data", async (_req, res) => {
-  const responses = await getAllSolarEclipse2024Data();
-  res.json({ responses });
-});
-
 router.get("/data/:uuid", async (req, res) => {
   const uuid = req.params.uuid as string;
   const response = await getSolarEclipse2024Data(uuid);


### PR DESCRIPTION
This PR removes the endpoint to get all of the solar eclipse data. We don't actually need it, and it makes managing the permission stuff easier without it.