### PR TITLE
Advanced weather time

### DIFF
--- a/src/stories/solar-eclipse-2024/database.ts
+++ b/src/stories/solar-eclipse-2024/database.ts
@@ -17,6 +17,7 @@ export const SolarEclipse2024Entry = S.struct({
   cloud_cover_selected_locations: LatLonArray,
   info_time_ms: S.optional(S.number.pipe(S.int()), { exact: true }),
   app_time_ms: S.optional(S.number.pipe(S.int()), { exact: true }),
+  advanced_weather_time_ms: S.optional(S.number.pipe(S.int()), { exact: true }),
 });
 
 export const SolarEclipse2024Update = S.struct({
@@ -24,6 +25,7 @@ export const SolarEclipse2024Update = S.struct({
   cloud_cover_selected_locations: S.optional(LatLonArray, { exact: true }),
   delta_info_time_ms: S.optional(S.number.pipe(S.int()), { exact: true }),
   delta_app_time_ms: S.optional(S.number.pipe(S.int()), { exact: true }),
+  delta_advanced_weather_time_ms: S.optional(S.number.pipe(S.int()), { exact: true }),
 });
 
 export type SolarEclipse2024DataT = S.Schema.To<typeof SolarEclipse2024Entry>;
@@ -72,6 +74,9 @@ export async function updateSolarEclipse2024Data(userUUID: string, update: Solar
   }
   if (update.delta_app_time_ms) {
     dbUpdate.app_time_ms = data.app_time_ms + update.delta_app_time_ms;
+  }
+  if (update.delta_advanced_weather_time_ms) {
+    dbUpdate.advanced_weather_time_ms = data.advanced_weather_time_ms + update.delta_advanced_weather_time_ms;
   }
   const result = await data.update(dbUpdate);
   return result !== null;

--- a/src/stories/solar-eclipse-2024/models/eclipse_data.ts
+++ b/src/stories/solar-eclipse-2024/models/eclipse_data.ts
@@ -9,6 +9,7 @@ export class SolarEclipse2024Data extends Model<InferAttributes<SolarEclipse2024
   declare cloud_cover_selected_locations_count: number;
   declare info_time_ms: CreationOptional<number>;
   declare app_time_ms: CreationOptional<number>;
+  declare advanced_weather_time_ms: CreationOptional<number>;
   declare timestamp: CreationOptional<Date>;
 }
 
@@ -47,6 +48,11 @@ export function initializeSolarEclipse2024DataModel(sequelize: Sequelize) {
       defaultValue: 0
     },
     app_time_ms: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    },
+    advanced_weather_time_ms: {
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 0

--- a/src/stories/solar-eclipse-2024/router.ts
+++ b/src/stories/solar-eclipse-2024/router.ts
@@ -40,6 +40,10 @@ router.get("/data", async (_req, res) => {
 router.get("/data/:uuid", async (req, res) => {
   const uuid = req.params.uuid as string;
   const response = await getSolarEclipse2024Data(uuid);
+  if (response === null) {
+    res.status(404).json({ error: "Specified user data does not exist" });
+    return;
+  }
   res.json({ response });
 });
 

--- a/src/stories/solar-eclipse-2024/sql/create_eclipse_data_table.sql
+++ b/src/stories/solar-eclipse-2024/sql/create_eclipse_data_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE SolarEclipse2024Data (
+	id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
+	user_uuid varchar(36) NOT NULL UNIQUE,
+    user_selected_locations JSON NOT NULL,
+    user_selected_locations_count INT NOT NULL,
+    cloud_cover_selected_locations JSON NOT NULL,
+    cloud_cover_selected_locations_count INT NOT NULL,
+    app_time_ms INT NOT NULL DEFAULT 0,
+    info_time_ms INT NOT NULL DEFAULT 0,
+    advanced_weather_time_ms INT NOT NULL DEFAULT 0,
+    timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    
+    PRIMARY KEY(id),
+    INDEX(user_uuid)
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;


### PR DESCRIPTION
This PR extends the solar eclipse API to include data about how much time the advanced weather screen is open. It also updates the solar eclipse `GET` endpoint to return a 404 status code if the specified user doesn't exist.