### PR TITLE
Remove length check on cloud cover locations

### DIFF
--- a/src/stories/solar-eclipse-2024/database.ts
+++ b/src/stories/solar-eclipse-2024/database.ts
@@ -81,7 +81,6 @@ export async function updateSolarEclipse2024Data(userUUID: string, update: Solar
   if (update.cloud_cover_selected_locations) {
     const selected = data.cloud_cover_selected_locations.concat(update.cloud_cover_selected_locations);
     dbUpdate.cloud_cover_selected_locations = selected;
-    dbUpdate.cloud_cover_selected_locations_count = selected.length;
   }
   if (update.text_search_selected_locations) {
     const selected = data.text_search_selected_locations.concat(update.text_search_selected_locations);


### PR DESCRIPTION
This PR removes the old check of the length of the selected cloud cover locations array to get the change in the count. The new check would actually overwrite this anyway...unless the update count didn't exist or was zero, in which case it wouldn't happen.