### PR TITLE
Rename routes for clarity

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -338,7 +338,7 @@ async function getHubbleMeasurementsForAsyncStudent(studentID: number, classID: 
   return getHubbleMeasurementsForStudentClasses(studentID, classIDs);
 }
 
-export async function getStageThreeMeasurements(studentID: number, classID: number | null, lastChecked: number | null = null): Promise<HubbleMeasurement[]> {
+export async function getClassMeasurements(studentID: number, classID: number | null, lastChecked: number | null = null): Promise<HubbleMeasurement[]> {
   const cls = classID !== null ? await findClassById(classID) : null;
   const asyncClass = cls?.asynchronous ?? true;
   let data: HubbleMeasurement[] | null;

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -20,7 +20,7 @@ import {
   removeHubbleMeasurement,
   setGalaxySpectrumStatus,
   getUncheckedSpectraGalaxies,
-  getStageThreeMeasurements,
+  getClassMeasurements,
   getAllHubbleMeasurements,
   getAllHubbleStudentData,
   getAllHubbleClassData,
@@ -254,7 +254,7 @@ router.get("/sample-galaxy", async (_req, res) => {
   res.json(galaxy);
 });
 
-router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
+router.get(["/class-measurements/:studentID/:classID", "/stage-3-data/:studentID/:classID"], async (req, res) => {
   const lastCheckedStr = req.query.last_checked as string;
   let lastChecked: number | null = parseInt(lastCheckedStr);
   if (isNaN(lastChecked)) {
@@ -283,7 +283,7 @@ router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
     return;
   }
 
-  const measurements = await getStageThreeMeasurements(studentID, classID, lastChecked);
+  const measurements = await getClassMeasurements(studentID, classID, lastChecked);
   res.status(200).json({
     studentID,
     classID,
@@ -291,7 +291,7 @@ router.get("/stage-3-data/:studentID/:classID", async (req, res) => {
   });
 });
 
-router.get("/stage-3-data/:studentID", async (req, res) => {
+router.get(["/class-measurements/:studentID", "stage-3-measurements/:studentID"], async (req, res) => {
   const params = req.params;
   const studentID = parseInt(params.studentID);
   const isValidStudent = (await findStudentById(studentID)) !== null;
@@ -302,7 +302,7 @@ router.get("/stage-3-data/:studentID", async (req, res) => {
     return;
   }
 
-  const measurements = await getStageThreeMeasurements(studentID, null);
+  const measurements = await getClassMeasurements(studentID, null);
   res.status(200).json({
     studentID,
     measurements,


### PR DESCRIPTION
With how the Hubble story is now organized, `/stage-3-data` is a pretty bad route name since we're not longer using that data in stage 3. This PR updates those routes to the more descriptive `/class-measurements` (which is what gets returned).

However, to avoid breaking anything, I've kept the `/stage-3-data` routes as well - the two routes just use the same handlers.