### PR TITLE
Make class measurement reponse keys consistent

### DIFF
--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -285,9 +285,9 @@ router.get(["/class-measurements/:studentID/:classID", "/stage-3-data/:studentID
 
   const measurements = await getClassMeasurements(studentID, classID, lastChecked);
   res.status(200).json({
-    studentID,
-    classID,
-    measurements
+    student_id: studentID,
+    class_id: classID,
+    measurements,
   });
 });
 
@@ -304,9 +304,9 @@ router.get(["/class-measurements/:studentID", "stage-3-measurements/:studentID"]
 
   const measurements = await getClassMeasurements(studentID, null);
   res.status(200).json({
-    studentID,
+    student_id: studentID,
+    class_id: null,
     measurements,
-    classID: null
   });
 });
 


### PR DESCRIPTION
The JSON returned from the `/class-measurements` (aka `/stage-3-data`) endpoints uses camelCase, whereas everything else is using JSON with snake_case keys. This PR modifies those endpoints to use snake_case for consistency.