### PR TITLE
Give a 404 from measurements endpoint if student doesn't exist

### DIFF
--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -188,7 +188,10 @@ router.delete("/sample-measurement/:studentID/:measurementNumber", async (req, r
 router.get("/measurements/:studentID", async (req, res) => {
   const params = req.params;
   const studentID = parseInt(params.studentID);
-  const measurements = await getStudentHubbleMeasurements(studentID);
+  const student = await findStudentById(studentID);
+  const measurements = student !== null ?
+    await getStudentHubbleMeasurements(studentID) :
+    null;
   const status = measurements === null ? 404 : 200;
   res.status(status).json({
     student_id: studentID,


### PR DESCRIPTION
Currently there's no way to determine whether an empty measurement response means "this student doesn't exist" or "they do exist, but they have no measurements". This PR updates the status code to be a 404 in the former case so that we can make that distinction.