### PR TITLE
Allow getting only complete class measurements

### DIFF
--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -263,6 +263,7 @@ router.get(["/class-measurements/:studentID/:classID", "/stage-3-data/:studentID
   if (isNaN(lastChecked)) {
     lastChecked = null;
   }
+  const completeOnly = (req.query.complete_only as string)?.toLowerCase() === "true";
   const params = req.params;
   let studentID = parseInt(params.studentID);
   let classID = parseInt(params.classID);
@@ -286,7 +287,7 @@ router.get(["/class-measurements/:studentID/:classID", "/stage-3-data/:studentID
     return;
   }
 
-  const measurements = await getClassMeasurements(studentID, classID, lastChecked);
+  const measurements = await getClassMeasurements(studentID, classID, lastChecked, completeOnly);
   res.status(200).json({
     student_id: studentID,
     class_id: classID,


### PR DESCRIPTION
It's often useful to get only class measurements that are complete (defined as the observed wavelength, velocity, angular size, and distance values all not being null). This PR allows doing that on the class measurements endpoint by using a `complete_only=true` query parameter. Note that the default behavior (without the query parameter) is unchanged.