### PR TITLE
Add endpoints for getting class size and Hubble measurement count

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ import {
   getStageState,
   updateStageState,
   deleteStageState,
+  findClassById,
 } from "./database";
 
 import { getAPIKey, hasPermission } from "./authorization";
@@ -415,6 +416,23 @@ app.get("/students", async (_req, res) => {
 app.get("/educators", async (_req, res) => {
   const queryResponse = await getAllEducators();
   res.json(queryResponse);
+});
+
+app.get("/classes/size/:classID", async (req, res) => {
+  const classID = Number(req.params.classID);
+  const cls = await findClassById(classID);
+  if (cls === null) {
+    res.status(404).json({
+      message: `Class ${classID} not found`,
+    });
+    return;
+  }
+
+  const size = classSize(classID);
+  res.json({
+    class_id: classID,
+    size
+  });
 });
 
 app.get("/story-state/:studentID/:storyName", async (req, res) => {

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -365,6 +365,26 @@ export async function getClassMeasurements(studentID: number,
   return data ?? [];
 }
 
+// The advantage of this over the function above is that it saves bandwidth,
+// since we aren't sending the data itself.
+// This is intended to be used with cases where we need to frequently check the class size,
+// e.g. the beginning of stage 4 in the Hubble story
+export async function getClassMeasurementCount(studentID: number,
+                                               classID: number | null,
+                                               excludeWithNull: boolean = false,
+): Promise<number> {
+    const cls = classID !== null ? await findClassById(classID) : null;
+    const asyncClass = cls?.asynchronous ?? true;
+    let data: HubbleMeasurement[] | null;
+    console.log(classID, asyncClass);
+    if (classID === null || asyncClass) {
+      data = await getHubbleMeasurementsForAsyncStudent(studentID, classID, excludeWithNull);
+    } else {
+      data = await getHubbleMeasurementsForSyncStudent(studentID, classID, excludeWithNull);
+    }
+    return data?.length ?? 0;
+}
+
 async function getHubbleStudentDataForAsyncStudent(studentID: number, classID: number | null): Promise<HubbleStudentData[] | null> {
   const classIDs = await getClassIDsForAsyncStudent(studentID, classID);
   return getHubbleStudentDataForClasses(classIDs);

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -32,7 +32,8 @@ import {
   getGalaxyById,
   removeSampleHubbleMeasurement,
   getAllNthSampleHubbleMeasurements,
-  tryToMergeClass
+  tryToMergeClass,
+  getClassMeasurementCount
 } from "./database";
 
 import { 
@@ -255,6 +256,33 @@ router.get("/sample-measurements/:measurementNumber", async (req, res) => {
 router.get("/sample-galaxy", async (_req, res) => {
   const galaxy = await getSampleGalaxy();
   res.json(galaxy);
+});
+
+router.get("/class-measurements/size/:studentID/:classID", async (req, res) => {
+  const studentID = parseInt(req.params.studentID);
+  const isValidStudent = (await findStudentById(studentID)) !== null;
+  if (!isValidStudent) {
+    res.status(404).json({
+      message: "Invalid student ID",
+    });
+    return;
+  }
+
+  const classID = parseInt(req.params.classID);
+  const isValidClass = (await findClassById(classID)) !== null;
+  if (!isValidClass) {
+    res.status(404).json({
+      message: "Invalid class ID",
+    });
+    return;
+  }
+
+  const completeOnly = (req.query.complete_only as string)?.toLowerCase() === "true";
+  const count = await getClassMeasurementCount(studentID, classID, completeOnly);
+  res.status(200).json({
+    student_id: studentID,
+    measurement_count: count,
+  });
 });
 
 router.get(["/class-measurements/:studentID/:classID", "/stage-3-data/:studentID/:classID"], async (req, res) => {


### PR DESCRIPTION
This PR adds two new endpoints to the server:
* `GET /classes/size/<class_id>` returns the number of students in the class
* `GET /hubbles_law/class-measurements/size/<student_id>/<class_id>` returns the number of class measurements for the given class. This allows a `complete_only` query parameter that, if true, will restrict the count only to completed measurements