### PR TITLE
Set headers to prevent caching of Hubble class measurement count responses

### DIFF
--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -259,6 +259,9 @@ router.get("/sample-galaxy", async (_req, res) => {
 });
 
 router.get("/class-measurements/size/:studentID/:classID", async (req, res) => {
+  res.header("Cache-Control", "no-cache, no-store, must-revalidate");  // HTTP 1.1
+  res.header("Pragma", "no-cache");  // HTTP 1.0
+  res.header("Expires", "0");  // Proxies
   const studentID = parseInt(req.params.studentID);
   const isValidStudent = (await findStudentById(studentID)) !== null;
   if (!isValidStudent) {


### PR DESCRIPTION
This PR updates the response headers for the HubbleDS class measurement count endpoints to try and prevent browser caching. This is necessary because this endpoint will be repeatedly called when checking the class size in stage 4, and we need a fresh value each time so that the app knows when to allow the student to advance.