### PR TITLE
Add endpoints for getting stages and stage states

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -36,6 +36,7 @@ import { initializeModels } from "./models";
 import { StudentOption, StudentOptions } from "./models/student_options";
 import { Question } from "./models/question";
 import { logger } from "./logger";
+import { Stage } from "./models/stage";
 
 type SequelizeError = { parent: { code: string } };
 
@@ -337,6 +338,19 @@ export async function getAllEducators(): Promise<Educator[]> {
   return Educator.findAll();
 }
 
+export async function getStory(storyName: string): Promise<Story | null> {
+  return Story.findOne({ where: { name: storyName } });
+}
+
+export async function getStages(storyName: string): Promise<Stage[]> {
+  return Stage.findAll({
+    where: {
+      story_name: storyName,
+    },
+    order: [['stage_index', 'ASC']],
+  });
+}
+
 export async function getStoryState(studentID: number, storyName: string): Promise<JSON | null> {
   const result = await StoryState.findOne({
     where: {
@@ -425,6 +439,19 @@ export async function deleteStageState(studentID: number, storyName: string, sta
       stage_name: stageName,
     }
   });
+}
+
+export async function getStageStates(studentID: number, storyName: string): Promise<Record<string, JSON>> {
+  const stages = await getStages(storyName);
+  const stageNames = stages.map(stage => stage.stage_name);
+  const stageStates: Record<string, JSON> = {};
+  for (const name of stageNames) {
+    const state = await getStageState(studentID, storyName, name);
+    if (state !== null) {
+      stageStates[name] = state;
+    }
+  }
+  return stageStates;
 }
 
 export async function getClassesForEducator(educatorID: number): Promise<Class[]> {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,6 +5,7 @@ import { Educator, initializeEducatorModel } from "./educator";
 import { IgnoreStudent, initializeIgnoreStudentModel } from "./ignore_student";
 import { ClassStories, initializeClassStoryModel } from "./story_class";
 import { CosmicDSSession, initializeSessionModel } from "./session";
+import { Stage, initializeStageModel } from "./stage";
 import { StageState, initializeStageStateModel } from "./stage_state";
 import { StoryState, initializeStoryStateModel } from "./story_state";
 import { Story, initializeStoryModel } from "./story";
@@ -23,6 +24,7 @@ export {
   DummyClass,
   Educator,
   IgnoreStudent,
+  Stage,
   StageState,
   Story,
   StoryState,
@@ -38,6 +40,7 @@ export function initializeModels(db: Sequelize) {
   initializeStoryModel(db);
   initializeClassStoryModel(db);
   initializeDummyClassModel(db);
+  initializeStageModel(db);
   initializeStageStateModel(db);
   initializeStoryStateModel(db);
   initializeStudentClassModel(db);

--- a/src/models/stage.ts
+++ b/src/models/stage.ts
@@ -1,0 +1,31 @@
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+
+
+export class Stage extends Model<InferAttributes<Stage>, InferCreationAttributes<Stage>> {
+  declare story_name: string;
+  declare stage_name: string;
+  declare stage_index: CreationOptional<number | null>;
+}
+
+export function initializeStageModel(sequelize: Sequelize) {
+  Stage.init({
+    story_name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+    stage_name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+    stage_index: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: true,
+      defaultValue: null,
+    }
+  }, {
+    sequelize,
+    engine: "InnoDB",
+  });
+}

--- a/src/models/stage.ts
+++ b/src/models/stage.ts
@@ -1,4 +1,5 @@
 import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+import { Story } from "./story";
 
 
 export class Stage extends Model<InferAttributes<Stage>, InferCreationAttributes<Stage>> {
@@ -13,11 +14,17 @@ export function initializeStageModel(sequelize: Sequelize) {
       type: DataTypes.STRING,
       allowNull: false,
       unique: true,
+      primaryKey: true,
     },
     stage_name: {
       type: DataTypes.STRING,
       allowNull: false,
       unique: true,
+      primaryKey: true,
+      references: {
+        model: Story,
+        key: "name",
+      }
     },
     stage_index: {
       type: DataTypes.INTEGER.UNSIGNED,
@@ -27,5 +34,19 @@ export function initializeStageModel(sequelize: Sequelize) {
   }, {
     sequelize,
     engine: "InnoDB",
+    indexes: [
+      {
+        unique: true,
+        fields: ["story_name", "stage_name"],
+      },
+      {
+        unique: true,
+        fields: ["story_name"],
+      },
+      {
+        unique: true,
+        fields: ["stage_name"],
+      },
+    ]
   });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,7 @@ import {
   VerificationResult,
 } from "./request_results";
 
-import { CosmicDSSession, StageState } from "./models";
+import { CosmicDSSession } from "./models";
 
 import { ParsedQs } from "qs";
 import express, { Request, Response as ExpressResponse, NextFunction } from "express";

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,9 @@ import {
   updateStageState,
   deleteStageState,
   findClassById,
+  getStages,
+  getStory,
+  getStageStates,
 } from "./database";
 
 import { getAPIKey, hasPermission } from "./authorization";
@@ -460,6 +463,47 @@ app.put("/story-state/:studentID/:storyName", async (req, res) => {
     story_name: storyName,
     state
   });
+});
+
+app.get("/stages/:storyName", async (req, res) => {
+  const storyName = req.params.storyName;
+  const story = await getStory(storyName);
+
+  if (story === null) {
+    res.status(404).json({
+      error: `No story found with name ${storyName}`
+    });
+    return;
+  }
+
+  const stages = await getStages(req.params.storyName);
+  res.json({
+    stages,
+  });
+});
+
+app.get("/stage-states/:studentID/:storyName", async (req, res) => {
+  const storyName = req.params.storyName;
+  const story = await getStory(storyName);
+
+  if (story === null) {
+    res.status(404).json({
+      error: `No story found with name ${storyName}`
+    });
+    return;
+  }
+
+  const studentID = Number(req.params.studentID);
+  const student = await findStudentById(studentID);
+  if (student === null) {
+    res.status(404).json({
+      error: `No student found with ID ${studentID}`
+    });
+    return;
+  }
+  
+  const stageStates = await getStageStates(studentID, storyName);
+  res.json(stageStates);
 });
 
 app.get("/stage-state/:studentID/:storyName/:stageName", async (req, res) => {

--- a/src/sql/create_stage_table.sql
+++ b/src/sql/create_stage_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE Stages (
+    story_name varchar(50) NOT NULL UNIQUE,
+    stage_name varchar(50) NOT NULL UNIQUE,
+    stage_index int(11) UNSIGNED DEFAULT NULL,
+
+    PRIMARY KEY(story_name, stage_name),
+    INDEX(story_name),
+    INDEX(stage_name),
+    FOREIGN KEY(story_name)
+        REFERENCES Stories(name)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;

--- a/src/sql/create_stage_table.sql
+++ b/src/sql/create_stage_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE Stages (
-    story_name varchar(50) NOT NULL UNIQUE,
-    stage_name varchar(50) NOT NULL UNIQUE,
+    story_name varchar(50) NOT NULL,
+    stage_name varchar(50) NOT NULL,
     stage_index int(11) UNSIGNED DEFAULT NULL,
 
     PRIMARY KEY(story_name, stage_name),


### PR DESCRIPTION
This PR adds the following endpoints:
* `GET /stages/<story name>` returns information about all of the stages for the given story
* `GET /stage-states/<student ID>/<story name>` returns all of the given student's stage states for the given story
    - The response object here is of the form { "stage_name": "stage_state", ... }

This PR also contains setup infrastructure for the new `Stages` table which contains information about all of the stages for a given story. We need to add these stages to this table ourselves - there isn't any process to autogenerate these from e.g. story code.