### PR TITLE
Make stage stages endpoint more flexible

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -483,6 +483,12 @@ app.get("/stages/:storyName", async (req, res) => {
   });
 });
 
+// Use query parameters `student_id`, `class_id`, and `stage_name` to filter output
+// `stage_name` is optional. If not specified, return value will be an object of the form
+// { stage1: [<states>], stage2: [<states>], ... }
+// If specified, this returns an object of the form [<states>]
+// At least one of `student_id` and `class_id` must be specified.
+// If both are specified, only `student_id` is used
 app.get("/stage-states/:storyName", async (req, res) => {
   const storyName = req.params.storyName;
   const story = await getStory(storyName);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,14 @@ import { Model } from "sequelize";
 // This type describes objects that we're allowed to pass to a model's `update` method
 export type UpdateAttributes<M extends Model> = Parameters<M["update"]>[0];
 
+export type Only<T, U> = {
+  [P in keyof T]: T[P];
+} & {
+  [P in keyof U]?: never;
+};
+
+export type Either<T, U> = Only<T,U> | Only<U,T>;
+
 export function createVerificationCode(): string {
   return nanoid(21);
 }


### PR DESCRIPTION
This PR updates the `/stage-states` endpoint to be more flexible. As there are a lot of possible ways that one could want to query for stage states, I decided that the most straightforward thing to do was to allow using query parameters.

See the comment before the new route for a description of what's returned. @johnarban would this work for what you need for the dashboard?