### PR TITLE
Use correct username when creating a student

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -257,7 +257,7 @@ export async function signUpStudent(options: SignUpStudentOptions): Promise<Sign
   
   let result = SignUpResult.Ok;
   const student = await Student.create({
-    username: username,
+    username: options.username,
     verified: 0,
     verification_code: verificationCode,
     password: encryptedPassword,


### PR DESCRIPTION
Thanks to @nmearl for noticing that we were using the wrong username when creating a student - we're using the global database username rather than the username that's passed in. Since `username` is defined when logging the server into the actual DB instance, this didn't show up as an error.