### PR TITLE
Validate request body structure

### DIFF
--- a/src/models/educator.ts
+++ b/src/models/educator.ts
@@ -10,9 +10,9 @@ export class Educator extends Model<InferAttributes<Educator>, InferCreationAttr
   declare first_name: string;
   declare last_name: string;
   declare password: string;
-  declare institution: string | null;
-  declare age: number | null;
-  declare gender: string | null;
+  declare institution: CreationOptional<string | null>;
+  declare age: CreationOptional<number | null>;
+  declare gender: CreationOptional<string | null>;
   declare ip: CreationOptional<string | null>;
   declare lat: CreationOptional<string | null>;
   declare lon: CreationOptional<string | null>;

--- a/src/request_results.ts
+++ b/src/request_results.ts
@@ -63,7 +63,15 @@ export enum SignUpResult {
 
 export namespace SignUpResult {
   export function statusCode(result: SignUpResult): number {
-    return result === SignUpResult.BadRequest ? 400 : 200;
+    switch (result) {
+      case SignUpResult.Ok:
+        return 200;
+      case SignUpResult.EmailExists:
+        return 409;
+      case SignUpResult.BadRequest:
+      case SignUpResult.Error:
+        return 400;
+    }
   }
 
   export function success(result: SignUpResult): boolean {

--- a/src/server.ts
+++ b/src/server.ts
@@ -244,9 +244,9 @@ app.post([
     result = await signUpEducator(maybe.right);
   } else {
     result = SignUpResult.BadRequest;
-    res.status(400);
   }
-  res.json({
+  const statusCode = SignUpResult.statusCode(result);
+  res.status(statusCode).json({
     educator_info: data,
     status: result,
     success: SignUpResult.success(result)
@@ -266,9 +266,9 @@ app.post([
     result = await signUpStudent(maybe.right);
   } else {
     result = SignUpResult.BadRequest;
-    res.status(400);
   }
-  res.json({
+  const statusCode = SignUpResult.statusCode(result);
+  res.status(statusCode).json({
     student_info: data,
     status: result,
     success: SignUpResult.success(result)

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,7 +45,6 @@ import {
   findEducatorById,
   CreateClassSchema,
   QuestionInfoSchema,
-  QuestionInfo,
 } from "./database";
 
 import { getAPIKey, hasPermission } from "./authorization";

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,9 @@ import {
   checkStudentLogin,
   createClass,
   signUpEducator,
+  SignUpStudentSchema,
   signUpStudent,
+  SignUpEducatorSchema,
   verifyEducator,
   verifyStudent,
   getAllEducators,
@@ -41,6 +43,9 @@ import {
   UserType,
   findEducatorByUsername,
   findEducatorById,
+  CreateClassSchema,
+  QuestionInfoSchema,
+  QuestionInfo,
 } from "./database";
 
 import { getAPIKey, hasPermission } from "./authorization";
@@ -66,7 +71,9 @@ import cors from "cors";
 import jwt from "jsonwebtoken";
 
 import { isStudentOption } from "./models/student_options";
-import { isNumberArray, isStringArray } from "./utils";
+
+import * as S from "@effect/schema/Schema";
+import * as Either from "effect/Either";
 
 export const app = express();
 
@@ -231,20 +238,11 @@ app.post([
   "/educator-sign-up", // Old
 ], async (req, res) => {
   const data = req.body;
-  const valid = (
-    typeof data.first_name === "string" &&
-    typeof data.last_name === "string" &&
-    typeof data.password === "string" &&
-    ((typeof data.institution === "string") || (data.institution == null)) &&
-    typeof data.email === "string" &&
-    typeof data.username === "string" &&
-    ((typeof data.age === "number") || (data.age == null)) &&
-    ((typeof data.gender === "string") || data.gender == null)
-  );
+  const maybe = S.decodeUnknownEither(SignUpEducatorSchema)(data);
 
   let result: SignUpResult;
-  if (valid) {
-    result = await signUpEducator(data);
+  if (Either.isRight(maybe)) {
+    result = await signUpEducator(maybe.right);
   } else {
     result = SignUpResult.BadRequest;
     res.status(400);
@@ -262,19 +260,11 @@ app.post([
   "/student-sign-up", // Old
 ], async (req, res) => {
   const data = req.body;
-  const valid = (
-    typeof data.username === "string" &&
-    typeof data.password === "string" &&
-    ((typeof data.institution === "string") || (data.institution == null)) &&
-    ((typeof data.email === "string") || (data.email == null)) &&
-    ((typeof data.age === "number") || (data.age == null)) &&
-    ((typeof data.gender === "string") || (data.gender == null)) &&
-    ((typeof data.classroom_code === "string") || (data.classroom_code == null))
-  );
+  const maybe = S.decodeUnknownEither(SignUpStudentSchema)(data);
 
   let result: SignUpResult;
-  if (valid) {
-    result = await signUpStudent(data);
+  if (Either.isRight(maybe)) {
+    result = await signUpStudent(maybe.right);
   } else {
     result = SignUpResult.BadRequest;
     res.status(400);
@@ -288,10 +278,14 @@ app.post([
 
 async function handleLogin(request: GenericRequest, identifierField: string, checker: (identifier: string, pw: string) => Promise<LoginResponse>): Promise<LoginResponse> {
   const data = request.body;
-  const valid = typeof data[identifierField] === "string" && typeof data.password === "string";
+  const schema = S.struct({
+    [identifierField]: S.string,
+    password: S.string,
+  });
+  const maybe = S.decodeUnknownEither(schema)(data);
   let res: LoginResponse;
-  if (valid) {
-    res = await checker(data[identifierField], data.password);
+  if (Either.isRight(maybe)) {
+    res = await checker(maybe.right[identifierField], maybe.right.password);
   } else {
     res = { result: LoginResult.BadRequest, success: false, type: "none" };
   }
@@ -353,29 +347,6 @@ app.put("/educator-login", async (req, res) => {
   }
   const status = loginResponse.success ? 200 : 401;
   res.status(status).json(loginResponse);
-});
-
-app.post("/create-class", async (req, res) => {
-  const data = req.body;
-  const valid = (
-    typeof data.educatorID === "number" &&
-    typeof data.name === "string"
-  );
-
-  let result: CreateClassResult;
-  let cls: object | undefined = undefined;
-  if (valid) {
-    const createClassResponse = await createClass(data.educatorID, data.name);
-    result = createClassResponse.result;
-    cls = createClassResponse.class;
-  } else {
-    result = CreateClassResult.BadRequest;
-    res.status(400);
-  }
-  res.json({
-    class: cls,
-    status: result
-  });
 });
 
 async function verify(request: VerificationRequest, verifier: (code: string) => Promise<VerificationResult>): Promise<{ code: string; status: VerificationResult }> {
@@ -567,15 +538,15 @@ app.post("/classes/join", async (req, res) => {
 });
 
 /* Classes */
-app.post("/classes/create", async (req, res) => {
+app.post([
+  "/classes/create",
+  "/create-class",
+], async (req, res) => {
   const data = req.body;
-  const valid = (
-    typeof data.username === "string" &&
-    typeof data.educator_id === "string"
-  );
+  const maybe = S.decodeUnknownEither(CreateClassSchema)(data);
   let response: CreateClassResponse;
-  if (valid) {
-    response = await createClass(data.educator_id, data.username);
+  if (Either.isRight(maybe)) {
+    response = await createClass(maybe.right);
   } else {
     response = {
       result: CreateClassResult.BadRequest,
@@ -855,22 +826,10 @@ app.get("/question/:tag", async (req, res) => {
 
 app.post("/question/:tag", async (req, res) => {
 
-  const tag = req.params.tag;
-  const text = req.body.text;
-  const shorthand = req.body.shorthand;
-  const story_name = req.body.story_name;
-  const answers_text = req.body.answers_text;
-  const correct_answers = req.body.correct_answers;
-  const neutral_answers = req.body.neutral_answers;
+  const data = { ...req.body, tag: req.params.tag };
+  const maybe = S.decodeUnknownEither(QuestionInfoSchema)(data);
 
-  const valid = typeof tag === "string" &&
-                typeof text === "string" &&
-                typeof shorthand === "string" &&
-                typeof story_name === "string" &&
-                (answers_text === undefined || isStringArray(answers_text)) &&
-                (correct_answers === undefined || isNumberArray(correct_answers)) &&
-                (neutral_answers === undefined || isNumberArray(neutral_answers));
-  if (!valid) {
+  if (Either.isLeft(maybe)) {
     res.statusCode = 400;
     res.json({
       error: "One of your fields is missing or of the incorrect type"
@@ -878,9 +837,10 @@ app.post("/question/:tag", async (req, res) => {
     return;
   }
 
-  const currentQuestion = await findQuestion(tag);
+  const currentQuestion = await findQuestion(req.params.tag);
   const version = currentQuestion !== null ? currentQuestion.version + 1 : 1;
-  const addedQuestion = await addQuestion({tag, text, shorthand, story_name, answers_text, correct_answers, neutral_answers, version});
+  const questionInfo = { ...maybe.right, version };
+  const addedQuestion = await addQuestion(questionInfo);
   if (addedQuestion === null) {
     res.statusCode = 500;
     res.json({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import { enc, SHA256 } from "crypto-js";
 import { v5 } from "uuid";
 
 import { Model } from "sequelize";
+import { CreateClassOptions } from "./database";
 
 // This type describes objects that we're allowed to pass to a model's `update` method
 export type UpdateAttributes<M extends Model> = Parameters<M["update"]>[0];
@@ -14,6 +15,10 @@ export type Only<T, U> = {
 };
 
 export type Either<T, U> = Only<T,U> | Only<U,T>;
+
+export type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+}
 
 export function createVerificationCode(): string {
   return nanoid(21);
@@ -29,8 +34,8 @@ function createV5(name: string): string {
   return v5(name, cdsNamespace);
 }
 
-export function createClassCode(educatorID: number, className: string) {
-  const nameString = `${educatorID}_${className}`;
+export function createClassCode(options: CreateClassOptions) {
+  const nameString = `${options.educator_id}_${options.name}`;
   return createV5(nameString);
 }
 


### PR DESCRIPTION
This PR updates our validation of request bodies, in particular for some endpoints where we want the payload to have a lot of fields. This should help with type-safety and ensuring that we don't pass malformed data objects into the database methods.