### PR TITLE
Allow returning minimal version of Hubble "all data"

### DIFF
--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -378,13 +378,14 @@ router.get(["/class-measurements/:studentID", "stage-3-measurements/:studentID"]
 });
 
 router.get("/all-data", async (req, res) => {
+  const minimal = (req.query?.minimal as string)?.toLowerCase() === "true";
   const beforeMs: number = parseInt(req.query.before as string);
   const before = isNaN(beforeMs) ? null : new Date(beforeMs);
   const [measurements, studentData, classData] =
     await Promise.all([
-      getAllHubbleMeasurements(before),
-      getAllHubbleStudentData(before),
-      getAllHubbleClassData(before)
+      getAllHubbleMeasurements(before, minimal),
+      getAllHubbleStudentData(before, minimal),
+      getAllHubbleClassData(before, minimal)
     ]);
   res.json({
     measurements,


### PR DESCRIPTION
This PR allows specifying, via a `minimal` query parameter, that we only want the values from the `/all-data` endpoint that are essential for the graphs using in the Hubble data story. As of the time of writing, this reduces the payload size to ~27% of the full data. This addresses the points currently outlined in #133.