### PR TITLE
Add endpoint for returning the list of students in a given class

### DIFF
--- a/src/associations.ts
+++ b/src/associations.ts
@@ -102,6 +102,15 @@ export function setUpAssociations() {
     foreignKey: "class_id"
   });
 
+  Student.hasMany(StudentsClasses, {
+    foreignKey: "student_id",
+  });
+  StudentsClasses.belongsTo(Student, {
+    as: "student",
+    targetKey: "id",
+    foreignKey: "student_id",
+  });
+
   Class.hasMany(StudentsClasses, {
     foreignKey: "class_id"
   });

--- a/src/database.ts
+++ b/src/database.ts
@@ -611,6 +611,19 @@ export async function getRosterInfo(classID: number, useDisplayNames = true): Pr
   }, {});
 }
 
+export async function getClassRoster(classID: number): Promise<Student[]> {
+  return Student.findAll({
+    include: [{
+      model: StudentsClasses,
+      required: true,
+      attributes: [],
+      where: {
+        class_id: classID,
+      },
+    }]
+  });
+}
+
 /** These functions are for testing purposes only */
 export async function newDummyClassForStory(storyName: string): Promise<{cls: Class, dummy: DummyClass}> {
   const ct = await Class.count({

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ import {
   findEducatorById,
   CreateClassSchema,
   QuestionInfoSchema,
+  getClassRoster,
 } from "./database";
 
 import {
@@ -487,6 +488,19 @@ export function createApp(db: Sequelize): Express {
       size
     });
   });
+
+  app.get("/classes/roster/:classID", async (req, res) => {
+    const classID = Number(req.params.classID);
+    const cls = await findClassById(classID);
+    if (cls === null) {
+      res.status(404).json({
+        error: `No class found with ID ${classID}`,
+      });
+    }
+
+    const students = await getClassRoster(classID);
+    res.json(students);
+  });
   
   app.get("/story-state/:studentID/:storyName", async (req, res) => {
     const params = req.params;
@@ -719,7 +733,6 @@ export function createApp(db: Sequelize): Express {
     });
   });
   
-  
   app.post("/question/:tag", async (req, res) => {
   
     const data = { ...req.body, tag: req.params.tag };
@@ -749,7 +762,6 @@ export function createApp(db: Sequelize): Express {
       question: addedQuestion
     });
   });
-  
   
   app.get("/questions/:storyName", async (req, res) => {
     const storyName = req.params.storyName;


### PR DESCRIPTION
This PR adds a simple `/classes/roster/<class ID>` endpoint that returns a list of all of the students in the specified class.