### PR TITLE
Improve Promise error handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,8 @@
     "parserOptions": {
         "ecmaVersion": "latest",
         "parser": "@typescript-eslint/parser",
-        "sourceType": "module"
+        "sourceType": "module",
+        "project": "./tsconfig.json"
     },
     "plugins": [
         "vue",
@@ -43,6 +44,7 @@
         "semi": [
             "error",
             "always"
-        ]
+        ],
+        "@typescript-eslint/no-floating-promises": "error"
     }
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,4 +1,4 @@
-import { BaseError, Model, Op, QueryTypes, Sequelize, UniqueConstraintError, WhereOptions } from "sequelize";
+import { BaseError, Model, Op, QueryTypes, Sequelize, Transaction, UniqueConstraintError, WhereOptions } from "sequelize";
 import dotenv from "dotenv";
 
 import * as S from "@effect/schema/Schema";
@@ -255,33 +255,48 @@ export async function signUpStudent(options: SignUpStudentOptions): Promise<Sign
   } while (!validCode);
   
   let result = SignUpResult.Ok;
-  const student = await Student.create({
-    username: options.username,
-    verified: 0,
-    verification_code: verificationCode,
-    password: encryptedPassword,
-    institution: options.institution,
-    email: options.email,
-    age: options.age,
-    gender: options.gender,
-  })
-  .catch(error => {
-    result = signupResultFromError(error);
-  });
-
-  // If the student has a valid classroom code,
-  // add them to the class
-  if (student && options.classroom_code) {
-    const cls = await findClassByCode(options.classroom_code);
-    if (cls !== null) {
-      const addToClass = await StudentsClasses.create({
-        student_id: student.id,
-        class_id: cls.id
-      });
-    }
+  const db = Student.sequelize;
+  if (db === undefined) {
+    return SignUpResult.Error;
   }
 
-  return result;
+  try {
+    const transactionResult = db.transaction(async transaction => {
+
+      const student = await Student.create({
+        username: options.username,
+        verified: 0,
+        verification_code: verificationCode,
+        password: encryptedPassword,
+        institution: options.institution,
+        email: options.email,
+        age: options.age,
+        gender: options.gender,
+      }, { transaction })
+      .catch(error => {
+        result = signupResultFromError(error);
+      });
+
+      // If the student has a valid classroom code,
+      // add them to the class
+      if (student && options.classroom_code) {
+        const cls = await findClassByCode(options.classroom_code);
+        if (cls !== null) {
+          await StudentsClasses.create({
+            student_id: student.id,
+            class_id: cls.id
+          }, { transaction });
+        }
+      }
+
+      return result;
+    });
+
+    return transactionResult;
+  } catch (error) {
+    console.log(error);
+    return SignUpResult.Error;
+  }
 }
 
 export const CreateClassSchema = S.struct({
@@ -296,23 +311,35 @@ export async function createClass(options: CreateClassOptions): Promise<CreateCl
   let result = CreateClassResult.Ok;
   const code = createClassCode(options);
   const creationInfo = { ...options, code };
-  const cls = await Class.create(creationInfo)
-  .catch(error => {
-    result = createClassResultFromError(error);
-  });
 
-  const info = result === CreateClassResult.Ok ? creationInfo : undefined;
-
-  // For the pilot, the Hubble Data Story will be the only option,
-  // so we'll automatically associate that with the class
-  if (cls) {
-    ClassStories.create({
-      story_name: "hubbles_law",
-      class_id: cls.id
-    });
+  const db = Class.sequelize;
+  if (db === undefined) {
+    return { result: CreateClassResult.Error };
   }
 
-  return { result: result, class: info };
+  try {
+    const transactionResult = await db.transaction(async transaction => {
+
+      const cls = await Class.create(creationInfo, { transaction });
+
+      // For the pilot, the Hubble Data Story will be the only option,
+      // so we'll automatically associate that with the class
+      if (cls) {
+        await ClassStories.create({
+          story_name: "hubbles_law",
+          class_id: cls.id
+        });
+      }
+
+      return creationInfo;
+    });
+
+    return { result: result, class: transactionResult };
+  } catch (error) {
+    result = (error instanceof BaseError) ? createClassResultFromError(error) : CreateClassResult.Error;
+    console.log(error);
+    return { result: CreateClassResult.Error };
+  }
 }
 
 export async function addStudentToClass(studentID: number, classID: number): Promise<StudentsClasses> {
@@ -637,7 +664,8 @@ export async function getClassRoster(classID: number): Promise<Student[]> {
 }
 
 /** These functions are for testing purposes only */
-export async function newDummyClassForStory(storyName: string): Promise<{cls: Class, dummy: DummyClass}> {
+export async function newDummyClassForStory(storyName: string, transaction?: Transaction): Promise<{cls: Class, dummy: DummyClass}> {
+  const trans = transaction ?? null;
   const ct = await Class.count({
     where: {
       educator_id: 0,
@@ -650,7 +678,7 @@ export async function newDummyClassForStory(storyName: string): Promise<{cls: Cl
     educator_id: 0,
     name: `DummyClass_${storyName}_${ct+1}`,
     code: "xxxxxx"
-  });
+  }, { transaction: trans });
   let dc = await DummyClass.findOne({ where: { story_name: storyName }} );
   if (dc !== null) {
     dc.update({ class_id: cls.id })
@@ -662,64 +690,77 @@ export async function newDummyClassForStory(storyName: string): Promise<{cls: Cl
     dc = await DummyClass.create({
       class_id: cls.id,
       story_name: storyName
-    });
+    }, { transaction: trans });
   }
   return { cls: cls, dummy: dc };
 }
 
 export async function newDummyStudent(seed = false,
                                       teamMember: string | null = null,
-                                      storyName: string | null = null): Promise<Student> {
+                                      storyName: string | null = null): Promise<Student | null> {
   const students = await Student.findAll();
   const ids: number[] = students.map(student => {
     if (!student) { return 0; }
     return typeof student.id === "number" ? student.id : 0;
   });
   const newID = Math.max(...ids) + 1;
-  const student = await Student.create({
-    username: `dummy_student_${newID}`,
-    verified: 1,
-    verification_code: `verification_${newID}`,
-    password: "dummypass",
-    institution: "Dummy",
-    email: `dummy_student_${newID}@dummy.school`,
-    age: null,
-    gender: null,
-    seed: seed ? 1 : 0,
-    team_member: teamMember,
-    dummy: true
-  });
 
-  // If we have a story name, and are creating a seed student, we want to add this student to the current "dummy class" for that story
-  if (seed && storyName !== null) {
-    let cls: Class | null = null;
-    let dummyClass = await DummyClass.findOne({ where: { story_name: storyName } });
-    let clsSize: number;
-    if (dummyClass === null) {
-      const res = await newDummyClassForStory(storyName);
-      dummyClass = res.dummy;
-      cls = res.cls;
-      clsSize = 0;
-    } else {
-      clsSize = await StudentsClasses.count({ where: { class_id: dummyClass.class_id } });
-    }
-    
-    const ct = Math.floor(Math.random() * 11) + 20;
-    if (clsSize > ct) {
-      const res = await newDummyClassForStory(storyName);
-      cls = res.cls;
-    } else {
-      cls = await Class.findOne({ where: { id: dummyClass.class_id } });
-    }
-    if (cls !== null) {
-      StudentsClasses.create({
-        class_id: cls.id,
-        student_id: student.id
-      });
-    }
+  const db = Student.sequelize;
+  if (db === undefined) {
+    return null;
   }
 
-  return student;
+  try {
+    const transactionResult = await db.transaction(async transaction => {
+      const student = await Student.create({
+        username: `dummy_student_${newID}`,
+        verified: 1,
+        verification_code: `verification_${newID}`,
+        password: "dummypass",
+        institution: "Dummy",
+        email: `dummy_student_${newID}@dummy.school`,
+        age: null,
+        gender: null,
+        seed: seed ? 1 : 0,
+        team_member: teamMember,
+        dummy: true
+      }, { transaction });
+
+      // If we have a story name, and are creating a seed student, we want to add this student to the current "dummy class" for that story
+      if (seed && storyName !== null) {
+        let cls: Class | null = null;
+        let dummyClass = await DummyClass.findOne({ where: { story_name: storyName } });
+        let clsSize: number;
+        if (dummyClass === null) {
+          const res = await newDummyClassForStory(storyName, transaction);
+          dummyClass = res.dummy;
+          cls = res.cls;
+          clsSize = 0;
+        } else {
+          clsSize = await StudentsClasses.count({ where: { class_id: dummyClass.class_id } });
+        }
+        
+        const ct = Math.floor(Math.random() * 11) + 20;
+        if (clsSize > ct) {
+          const res = await newDummyClassForStory(storyName);
+          cls = res.cls;
+        } else {
+          cls = await Class.findOne({ where: { id: dummyClass.class_id } });
+        }
+        if (cls !== null) {
+          await StudentsClasses.create({
+            class_id: cls.id,
+            student_id: student.id
+          }, { transaction });
+        }
+      }
+      return student;
+    });
+    return transactionResult;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
 }
 
 export async function classForStudentStory(studentID: number, storyName: string): Promise<Class | null> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,12 @@ promises.readdir(STORIES_DIR, { withFileTypes: true }).then(entries => {
       app.use(data.path, data.router);
     }
   });
+})
+
+// We should just fail if this step doesn't succeed
+.catch(error => {
+  console.error(error);
+  throw new Error("Error setting up sub-routers!");
 });
 
 // set port, listen for requests

--- a/src/request_results.ts
+++ b/src/request_results.ts
@@ -83,7 +83,8 @@ export enum VerificationResult {
   BadRequest = "bad_request",
   Ok = "ok",
   AlreadyVerified = "already_verified",
-  InvalidCode = "invalid_code"
+  InvalidCode = "invalid_code",
+  Error = "internal_server_error",
 }
 
 export namespace VerificationResult {

--- a/src/server.ts
+++ b/src/server.ts
@@ -273,6 +273,8 @@ export function createApp(db: Sequelize): Express {
         return 401;
       case VerificationResult.AlreadyVerified:
         return 409;
+      case VerificationResult.Error:
+        return 500;
     }
   }
   
@@ -458,18 +460,33 @@ export function createApp(db: Sequelize): Express {
   });
   
   app.delete("/classes/:code", async (req, res) => {
-    const cls = await findClassByCode(req.params.code);
-    const success = cls !== null;
-    if (!success) {
-      res.status(400);
+    const code = req.params.code;
+    const cls = await findClassByCode(code);
+    if (cls === null) {
+      res.status(404).json({
+        success: false,
+        error: `Could not find class with code ${code}`,
+      });
+      return;
     }
-    cls?.destroy();
-    const message = success ?
-      "Class deleted" :
-      "No class with the given code exists";
+    const success = await cls.destroy()
+      .then(() => true)
+      .catch(error => {
+        console.log(error);
+        return false;
+      });
+
+    if (!success) {
+      res.status(500).json({
+        success: false,
+        error: `Server error deleting class with code ${code}`,
+      });
+      return;
+    }
+
     res.json({
-      success,
-      message
+      success: true,
+      message: "Class deleted",
     });
   });
       

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -623,16 +623,31 @@ export async function getSampleGalaxy(): Promise<Galaxy | null> {
   });
 }
 
-export async function markGalaxyBad(galaxy: Galaxy): Promise<void> {
-  galaxy.update({ marked_bad: galaxy.marked_bad + 1 });
+export async function markGalaxyBad(galaxy: Galaxy): Promise<boolean> {
+  return galaxy.update({ marked_bad: galaxy.marked_bad + 1 })
+    .then(() => true)
+    .catch(error => {
+      console.log(error);
+      return false;
+    });
 }
 
-export async function markGalaxySpectrumBad(galaxy: Galaxy): Promise<void> {
-  galaxy.update({ spec_marked_bad: galaxy.spec_marked_bad + 1 });
+export async function markGalaxySpectrumBad(galaxy: Galaxy): Promise<boolean> {
+  return galaxy.update({ spec_marked_bad: galaxy.spec_marked_bad + 1 })
+    .then(() => true)
+    .catch(error => {
+      console.log(error);
+      return false;
+    });
 }
 
-export async function markGalaxyTileloadBad(galaxy: Galaxy): Promise<void> {
-  galaxy.update({ tileload_marked_bad: galaxy.tileload_marked_bad + 1 });
+export async function markGalaxyTileloadBad(galaxy: Galaxy): Promise<boolean> {
+  return galaxy.update({ tileload_marked_bad: galaxy.tileload_marked_bad + 1 })
+    .then(() => true)
+    .catch(error => {
+      console.log(error);
+      return false;
+    });
 }
 
 export async function getAsyncMergedClassIDForStudent(studentID: number): Promise<number | null> {

--- a/src/tests/root.test.ts
+++ b/src/tests/root.test.ts
@@ -4,7 +4,7 @@ import testApp, { authorizedRequest } from "./utils";
 
 describe("Test root route", async() => {
   it("Should show a welcome message", async () => {
-    authorizedRequest(testApp)
+    void authorizedRequest(testApp)
       .get("/")
       .expect(200)
       .expect("Content-Type", /json/)

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -19,7 +19,11 @@ export function unauthorizedRequest(app: Express) {
 
 function createTestDatabase(): Sequelize {
   const db = new Sequelize({ dialect: "mysql" });
-  db.query("CREATE DATABASE IF NOT EXISTS test");
+  db.query("CREATE DATABASE IF NOT EXISTS test")
+  .catch(error => {
+    console.log(error);
+    throw new Error(`Error creating test database: ${error}`);
+  });
   return db;
 }
 


### PR DESCRIPTION
This PR is intended to help with #139. While this doesn't prevent any possible errors, this PR enables the `@typescript-eslint/no-floating-promises` rule to help make sure that we're handling our promises correctly. This also fixes the issues that were flagged by that rule. In most cases this amounted to some straightforward error handling, but there were a few endpoints that do multiple inserts into tables where I decided that the best way to handle things was by refactoring to use [transactions](https://dev.mysql.com/doc/refman/8.4/en/sql-transactional-statements.html).