### PR TITLE
Change stories to be active by default when associated with a class

### DIFF
--- a/src/models/story_class.ts
+++ b/src/models/story_class.ts
@@ -31,7 +31,7 @@ export function initializeClassStoryModel(sequelize: Sequelize) {
     active: {
       type: DataTypes.TINYINT,
       allowNull: false,
-      defaultValue: 0,
+      defaultValue: 1,
     }
   }, {
     sequelize,

--- a/src/sql/create_class_story_table.sql
+++ b/src/sql/create_class_story_table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE ClassStories (
     class_id int(11) UNSIGNED NOT NULL,
     story_name varchar(50) NOT NULL,
-    active tinyint(2) NOT NULL DEFAULT 0,
+    active tinyint(2) NOT NULL DEFAULT 1,
 
     PRIMARY KEY(class_id, story_name),
     INDEX(class_id),


### PR DESCRIPTION
This PR resolves #145 by making the default value of `active` be 1 in `ClassStories`.