### PR TITLE
Add small class flag

### DIFF
--- a/src/models/class.ts
+++ b/src/models/class.ts
@@ -12,6 +12,7 @@ export class Class extends Model<InferAttributes<Class>, InferCreationAttributes
   declare asynchronous: CreationOptional<boolean>;
   declare test: CreationOptional<boolean>;
   declare expected_size: CreationOptional<number>;
+  declare small_class: CreationOptional<boolean>;
 }
 
 export function initializeClassModel(sequelize: Sequelize) {
@@ -66,6 +67,9 @@ export function initializeClassModel(sequelize: Sequelize) {
     expected_size: {
       type: DataTypes.INTEGER.UNSIGNED,
       allowNull: false,
+    },
+    small_class: {
+      type: "tinyint(1) GENERATED ALWAYS AS (expected_size < 10) VIRTUAL",
     },
   }, {
     sequelize,

--- a/src/sql/create_class_table.sql
+++ b/src/sql/create_class_table.sql
@@ -9,6 +9,7 @@ CREATE TABLE Classes (
     test tinyint(1) NOT NULL DEFAULT 0,
     updated datetime DEFAULT NULL,
     expected_size int(11) UNSIGNED NOT NULL,
+    small_class tinyint(1) GENERATED ALWAYS AS (expected_size < 10) VIRTUAL,
  
     PRIMARY KEY(id),
     INDEX(educator_id),


### PR DESCRIPTION
This PR updates our SQL definition and model to account for the newly-added `small_class` flag field. This field is a [virtual generated column](https://dev.mysql.com/doc/refman/8.4/en/create-table-generated-columns.html) that is true if `expected_size` is less than 10. The nice thing about this approach is that, if we change our small class criterion at some point in the future, we only need to update the column definition.