### PR TITLE
Allow creating asynchronous class via endpoint

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -312,6 +312,7 @@ export const CreateClassSchema = S.struct({
   educator_id: S.number,
   name: S.string,
   expected_size: S.number.pipe(S.int()),
+  asynchronous: S.optional(S.boolean),
 });
 
 export type CreateClassOptions = S.Schema.To<typeof CreateClassSchema>;


### PR DESCRIPTION
Our classes table already has an `asynchronous` flag, but it's not possible to mark a class as asynchronous when creating it via the API endpoint. This PR allows setting the flag as an option.