### PR TITLE
Update small class size

### DIFF
--- a/src/sql/create_class_table.sql
+++ b/src/sql/create_class_table.sql
@@ -9,7 +9,7 @@ CREATE TABLE Classes (
     test tinyint(1) NOT NULL DEFAULT 0,
     updated datetime DEFAULT NULL,
     expected_size int(11) UNSIGNED NOT NULL,
-    small_class tinyint(1) GENERATED ALWAYS AS (expected_size < 10) VIRTUAL,
+    small_class tinyint(1) GENERATED ALWAYS AS (expected_size < 12) VIRTUAL,
  
     PRIMARY KEY(id),
     INDEX(educator_id),


### PR DESCRIPTION
We've updated the small class criterion from 10 to 12, so this PR updates our SQL definition to account for that.