### PR TITLE
Update small class size from 12 to 15

### DIFF
--- a/src/models/class.ts
+++ b/src/models/class.ts
@@ -69,7 +69,7 @@ export function initializeClassModel(sequelize: Sequelize) {
       allowNull: false,
     },
     small_class: {
-      type: "tinyint(1) GENERATED ALWAYS AS (expected_size < 10) VIRTUAL",
+      type: "tinyint(1) GENERATED ALWAYS AS (expected_size < 15) VIRTUAL",
     },
   }, {
     sequelize,

--- a/src/sql/create_class_table.sql
+++ b/src/sql/create_class_table.sql
@@ -9,7 +9,7 @@ CREATE TABLE Classes (
     test tinyint(1) NOT NULL DEFAULT 0,
     updated datetime DEFAULT NULL,
     expected_size int(11) UNSIGNED NOT NULL,
-    small_class tinyint(1) GENERATED ALWAYS AS (expected_size < 12) VIRTUAL,
+    small_class tinyint(1) GENERATED ALWAYS AS (expected_size < 15) VIRTUAL,
  
     PRIMARY KEY(id),
     INDEX(educator_id),


### PR DESCRIPTION
We've updated the small class definition in the database to now be classes less than 15. This PR updates our model and SQL definitions to reflect that.