### PR TITLE
Use 15 instead of 12 as the cutoff size when looking for a merge class

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -781,7 +781,7 @@ export async function findClassForMerge(database: Sequelize, classID: number): P
     		INNER JOIN
     		(
     			SELECT * FROM StudentsClasses GROUP BY class_id
-    			HAVING COUNT(student_id) >= 12
+    			HAVING COUNT(student_id) >= 15
     		) C
     		ON Classes.id = C.class_id
     WHERE id != ${classID}


### PR DESCRIPTION
#157 still used 12 as the "small class" cutoff size, but we recently changed that to 15. This PR updates that.