### PR TITLE
Allow ignoring merge order when fetching merged classes

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -320,7 +320,7 @@ async function getClassIDsForSyncClass(classID: number): Promise<number[]> {
   return classIDs;
 }
 
-export async function getMergedIDsForClass(classID: number): Promise<number[]> {
+export async function getMergedIDsForClass(classID: number, ignoreMergeOrder=false): Promise<number[]> {
   // TODO: Currently this uses two queries:
   // The first to get the merge group (if there is one)
   // Then a second to get all of the classes in the merge group
@@ -334,14 +334,15 @@ export async function getMergedIDsForClass(classID: number): Promise<number[]> {
     return [classID];
   }
 
-  const mergeEntries = await HubbleClassMergeGroup.findAll({
-    where: {
-      group_id: mergeGroup.group_id,
-      merge_order: {
-        [Op.lte] : mergeGroup.merge_order,
-      }
-    }
-  });
+  const where: WhereOptions = {
+    group_id: mergeGroup.group_id,
+  };
+  if (!ignoreMergeOrder) {
+    where.merge_order = {
+      [Op.lte]: mergeGroup.merge_order,
+    };
+  }
+  const mergeEntries = await HubbleClassMergeGroup.findAll({ where });
   return mergeEntries.map(entry => entry.class_id);
 }
 

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -401,6 +401,7 @@ router.get(["/class-measurements/:studentID", "stage-3-measurements/:studentID"]
 
 router.get("/merged-classes/:classID", async (req, res) => {
   const classID = Number(req.params.classID);
+  const ignoreMergeOrder = (req.query?.ignore_merge_order as string)?.toLowerCase() === "true";
   const cls = await findClassById(classID);
   if (cls === null) {
     res.status(404).json({
@@ -408,7 +409,7 @@ router.get("/merged-classes/:classID", async (req, res) => {
     });
     return;
   }
-  const classIDs = await getMergedIDsForClass(classID);
+  const classIDs = await getMergedIDsForClass(classID, ignoreMergeOrder);
   res.json({
     merged_class_ids: classIDs,
   });


### PR DESCRIPTION
This PR adds an optional `ignore_merge_order` query parameter to the `/hubbles_law/merged-classes` endpoint. While we want to keep merge order in mind when fetching class measurements in the Hubble app itself, it will certainly be convenient for our other apps to be able to fetch the full list of merged classes, including ones merge in after. One example of this would be for creating some of the statistics in the Hubble summary tables.