### PR TITLE
Allow omitting class when fetching all data

### DIFF
--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -454,13 +454,17 @@ router.put("/merge-class", async (req, res) => {
 
 router.get("/all-data", async (req, res) => {
   const minimal = (req.query?.minimal as string)?.toLowerCase() === "true";
+  let classID: number | null = parseInt(req.query.class_id as string);
+  if (isNaN(classID)) {
+    classID = null;
+  }
   const beforeMs: number = parseInt(req.query.before as string);
   const before = isNaN(beforeMs) ? null : new Date(beforeMs);
   const [measurements, studentData, classData] =
     await Promise.all([
-      getAllHubbleMeasurements(before, minimal),
-      getAllHubbleStudentData(before, minimal),
-      getAllHubbleClassData(before, minimal)
+      getAllHubbleMeasurements(before, minimal, classID),
+      getAllHubbleStudentData(before, minimal, classID),
+      getAllHubbleClassData(before, minimal, classID)
     ]);
   res.json({
     measurements,


### PR DESCRIPTION
This PR allows specifying a `class_id` (intended to be the class of the current student) when calling the `hubbles_law/all-data` endpoint. If a class ID is given, all of the data from that class (and any that are merged with it, regardless of merge order) is omitted in the response.