### PR TITLE
Add waiting room overrides for Hubble story

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -1,5 +1,5 @@
 import { Attributes, FindOptions, Op, QueryTypes, Sequelize, WhereAttributeHash, WhereOptions, col, fn, literal } from "sequelize";
-import { AsyncMergedHubbleStudentClasses, Galaxy, HubbleMeasurement, SampleHubbleMeasurement, SyncMergedHubbleClasses } from "./models";
+import { AsyncMergedHubbleStudentClasses, Galaxy, HubbleMeasurement, HubbleWaitingRoomOverride, SampleHubbleMeasurement, SyncMergedHubbleClasses } from "./models";
 import { classSize, findClassById, findStudentById } from "../../database";
 import { RemoveHubbleMeasurementResult, SubmitHubbleMeasurementResult } from "./request_results";
 import { Class, StoryState, Student, StudentsClasses } from "../../models";
@@ -847,4 +847,24 @@ export async function addClassToMergeGroup(classID: number): Promise<number | nu
 
   return mergeGroup.group_id;
 
+}
+
+export async function setWaitingRoomOverride(classID: number): Promise<boolean | Error> {
+  return HubbleWaitingRoomOverride.findOrCreate({
+    where: {
+      class_id: classID,
+    }
+  })
+  .then(result => result[1])
+  .catch((error: Error) => error);
+}
+
+export async function removeWaitingRoomOverride(classID: number): Promise<boolean> {
+  return HubbleWaitingRoomOverride.destroy({
+    where: {
+      class_id: classID,
+    }
+  })
+  .then(_result => true)
+  .catch(_error => false);
 }

--- a/src/stories/hubbles_law/models/hubble_waiting_room_override.ts
+++ b/src/stories/hubbles_law/models/hubble_waiting_room_override.ts
@@ -1,0 +1,28 @@
+import { Class } from "../../../models";
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+
+export class HubbleWaitingRoomOverride extends Model<InferAttributes<HubbleWaitingRoomOverride>, InferCreationAttributes<HubbleWaitingRoomOverride>> {
+  declare class_id: number;
+  declare timestamp: CreationOptional<Date>;
+}
+
+export function initializeHubbleWaitingRoomOverrideModel(sequelize: Sequelize) {
+  HubbleWaitingRoomOverride.init({
+    class_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Class,
+        key: "id",
+      }
+    },
+    timestamp: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
+    }
+  }, {
+    sequelize,
+  });
+}

--- a/src/stories/hubbles_law/models/index.ts
+++ b/src/stories/hubbles_law/models/index.ts
@@ -7,13 +7,15 @@ import { Sequelize } from "sequelize";
 import { initializeHubbleStudentDataModel } from "./hubble_student_data";
 import { initializeHubbleClassDataModel } from "./hubble_class_data";
 import { initializeHubbleClassMergeGroupModel } from "./hubble_class_merge_group";
+import { initializeHubbleWaitingRoomOverrideModel, HubbleWaitingRoomOverride } from "./hubble_waiting_room_override";
 
 export {
   Galaxy,
   HubbleMeasurement,
   SampleHubbleMeasurement,
   AsyncMergedHubbleStudentClasses,
-  SyncMergedHubbleClasses
+  SyncMergedHubbleClasses,
+  HubbleWaitingRoomOverride
 };
 
 export function initializeModels(db: Sequelize) {
@@ -25,4 +27,5 @@ export function initializeModels(db: Sequelize) {
   initializeHubbleStudentDataModel(db);
   initializeHubbleClassDataModel(db);
   initializeHubbleClassMergeGroupModel(db);
+  initializeHubbleWaitingRoomOverrideModel(db);
 }

--- a/src/stories/hubbles_law/sql/create_hubble_waiting_room_overrides.sql
+++ b/src/stories/hubbles_law/sql/create_hubble_waiting_room_overrides.sql
@@ -1,0 +1,11 @@
+CREATE TABLE HubbleWaitingRoomOverrides (
+    class_id int(11) UNSIGNED NOT NULL,
+    timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY(class_id),
+    FOREIGN KEY(class_id)
+        REFERENCES Classes(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;


### PR DESCRIPTION
This PR adds the necessary functionality to enable teachers to override the waiting room in the Hubble's Law story (which will lead to the same behavior as if their class were a small class):
* Add `HubbleWaitingRoomOverrides` table and model
* Add endpoint `hubbles_law/waiting-room-override` which accepts `PUT` and `DELETE` requests to allow adding and removing this designation