### PR TITLE
More waiting room override functionality

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -849,6 +849,14 @@ export async function addClassToMergeGroup(classID: number): Promise<number | nu
 
 }
 
+export async function getWaitingRoomOverride(classID: number): Promise<HubbleWaitingRoomOverride | null> {
+  return HubbleWaitingRoomOverride.findOne({
+    where: {
+      class_id: classID,
+    }
+  });
+}
+
 export async function setWaitingRoomOverride(classID: number): Promise<boolean | Error> {
   return HubbleWaitingRoomOverride.findOrCreate({
     where: {
@@ -859,12 +867,11 @@ export async function setWaitingRoomOverride(classID: number): Promise<boolean |
   .catch((error: Error) => error);
 }
 
-export async function removeWaitingRoomOverride(classID: number): Promise<boolean> {
+export async function removeWaitingRoomOverride(classID: number): Promise<number> {
   return HubbleWaitingRoomOverride.destroy({
     where: {
       class_id: classID,
     }
   })
-  .then(_result => true)
-  .catch(_error => false);
+  .catch(_error => NaN);
 }


### PR DESCRIPTION
This PR builds on the waiting room overrides introduced in #161 with the following changes:
* Add a `GET /hubbles_law/waiting-room-override/<classID>` endpoint to get the waiting room override status of a class
* Update the `PUT` and `DELETE` handlers for the `/hubbles_law/waiting-room-override` endpoint to add/remove a class from a merge group as needed