### PR TITLE
Automatically add small and asynchronous classes to merge groups

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -350,10 +350,10 @@ export async function createClass(options: CreateClassOptions): Promise<CreateCl
     });
 
     // Another piece of Hubble-specific functionality
-    // Note that the virtual `small_class` column hasn't been populated yet
-    // So we need to check the condition manually
-    // TODO: How to not need to do this?
-    if (cls.asynchronous || cls.expected_size < 15) {
+    // Note that we need to re-query for the class as the virtual `small_class`
+    // column is only evaluted on a read (not the insert that we just did)
+    const createdClass = await findClassById(cls.id);
+    if (createdClass && (createdClass.asynchronous || createdClass.small_class)) {
       await addClassToMergeGroup(cls.id);
     }
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -41,6 +41,7 @@ import { StudentOption, StudentOptions } from "./models/student_options";
 import { Question } from "./models/question";
 import { logger } from "./logger";
 import { Stage } from "./models/stage";
+import { addClassToMergeGroup } from "./stories/hubbles_law/database";
 
 export type LoginResponse = {
   type: "none" | "student" | "educator" | "admin",
@@ -335,11 +336,18 @@ export async function createClass(options: CreateClassOptions): Promise<CreateCl
 
       // For the pilot, the Hubble Data Story will be the only option,
       // so we'll automatically associate that with the class
+      // TODO: When there are more classes available, we need to make
+      // this functionality more generic
       if (cls) {
         await ClassStories.create({
           story_name: "hubbles_law",
           class_id: cls.id
         }, { transaction });
+
+        // This piece in particular is very Hubble-specific
+        if (cls.asynchronous || cls.small_class) {
+          await addClassToMergeGroup(cls.id);
+        }
       }
 
       return creationInfo;

--- a/src/database.ts
+++ b/src/database.ts
@@ -350,10 +350,10 @@ export async function createClass(options: CreateClassOptions): Promise<CreateCl
     });
 
     // Another piece of Hubble-specific functionality
-    // Note that we need to re-query for the class as the virtual `small_class`
-    // column is only evaluted on a read (not the insert that we just did)
-    const createdClass = await findClassById(cls.id);
-    if (createdClass && (createdClass.asynchronous || createdClass.small_class)) {
+    // Note that we need to reload the class so that the virtual `small_class`
+    // column has its value populated
+    await cls.reload();
+    if (cls.asynchronous || cls.small_class) {
       await addClassToMergeGroup(cls.id);
     }
 


### PR DESCRIPTION
This PR updates the class creation endpoint handler to automatically add small and asynchronous classes to a Hubble merge group. This is largely a straightforward operation. As I mention in the comments, we probably want to have a way to more generically handle class-specific updates once we add more stories to the mix, but we can address that problem once we get there and have a better idea what we might want to do.