### PR TITLE
Return merged class ID in all data measurements

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -8,7 +8,6 @@ import { HubbleClassData } from "./models/hubble_class_data";
 import { IgnoreStudent } from "../../models/ignore_student";
 import { logger } from "../../logger";
 import { HubbleClassMergeGroup } from "./models/hubble_class_merge_group";
-import { QueryOptions } from "mysql2";
 
 const galaxyAttributes = ["id", "ra", "decl", "z", "type", "name", "element"];
 

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -320,7 +320,7 @@ async function getClassIDsForSyncClass(classID: number): Promise<number[]> {
   return classIDs;
 }
 
-export async function getMergedIDsForClass(classID: number, ignoreMergeOrder=false, mergeOrderSort: "ASC" | "DESC" | null = null): Promise<number[]> {
+export async function getMergedIDsForClass(classID: number, ignoreMergeOrder=false): Promise<number[]> {
   // TODO: Currently this uses two queries:
   // The first to get the merge group (if there is one)
   // Then a second to get all of the classes in the merge group
@@ -342,11 +342,7 @@ export async function getMergedIDsForClass(classID: number, ignoreMergeOrder=fal
       [Op.lte]: mergeGroup.merge_order,
     };
   }
-  const query: FindOptions = { where };
-  if (mergeOrderSort) {
-    query.order = [["merge_order", mergeOrderSort]];
-  }
-  const mergeEntries = await HubbleClassMergeGroup.findAll(query);
+  const mergeEntries = await HubbleClassMergeGroup.findAll({ where });
   return mergeEntries.map(entry => entry.class_id);
 }
 

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -499,19 +499,36 @@ export async function getAllHubbleMeasurements(before: Date | null = null,
     }]
   }) as (HubbleMeasurement & { class_id: number })[];
 
-  const mergeIDsToUse: Record<number, number | undefined> = {};
-  for (const measurement of measurements) {
-    const cid = measurement.class_id;
-    let mergedID = mergeIDsToUse[cid];
-    if (mergedID === undefined) {
-      const mergedIDs = await getMergedIDsForClass(cid, true, "DESC");
-      mergedID = mergedIDs[0];
-      mergedIDs.forEach(id => {
-        mergeIDsToUse[id] = mergedID;
-      });
+  const classIDs = new Set<number>();
+  measurements.forEach(measurement => classIDs.add(measurement.class_id));
+  const mergeGroupData = await HubbleClassMergeGroup.findAll({
+    attributes: [
+      "class_id",
+      "group_id",
+      // We use a RANK rather than the merge order because we don't know what the highest merge order value will be
+      // But the best rank will always be 1
+      [Sequelize.literal("RANK() OVER(PARTITION BY group_id ORDER BY merge_order DESC)"), "rk"],
+    ],
+    order: [["rk", "ASC"]],
+  }) as (HubbleClassMergeGroup & { rk: number })[];
+
+  const mergeIDsToUse: Record<number, number> = {};
+  const groupIDs: Record<number, number | undefined> = {};
+  mergeGroupData.forEach(data => {
+    // Because this is a column constructed inside the query,
+    // it doesn't work to do `data.rk`, or `data.getDataValue("rk")`
+    const rank = data.get("rk");
+    if (rank === 1) {
+      mergeIDsToUse[data.class_id] = data.class_id;
+      groupIDs[data.group_id] = data.class_id;
+    } else {
+      mergeIDsToUse[data.class_id] = groupIDs[data.group_id] ?? data.class_id;
     }
-    measurement.class_id = mergedID;
-  }
+  });
+
+  measurements.forEach(measurement => {
+    measurement.class_id = mergeIDsToUse[measurement.class_id] ?? measurement.class_id;
+  });
 
   return measurements;
 


### PR DESCRIPTION
While we currently combine Hubble merge groups for the purposes of doing the class summaries, the returned values from the `/hubbles_law/all-data` endpoint have their original class IDs. This makes subsetting difficult client-side in the Hubble app. The merge group stuff should IMO be completely transparent to the client, so instead what we do here is to make sure that the measurements from other classes are returned using the class ID of the class that's used for the summary.