### PR TITLE
Reduce length of class codes

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -326,7 +326,7 @@ export type CreateClassOptions = S.Schema.To<typeof CreateClassSchema>;
 export async function createClass(options: CreateClassOptions): Promise<CreateClassResponse> {
   
   let result = CreateClassResult.Ok;
-  const code = createClassCode(options);
+  const code = await createClassCode();
   const creationInfo = { ...options, code };
 
   const db = Class.sequelize;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,6 @@ import { enc, SHA256 } from "crypto-js";
 import { v5 } from "uuid";
 
 import { Model } from "sequelize";
-import { CreateClassOptions } from "./database";
 
 import { ParsedQs } from "qs";
 import { Request } from "express";
@@ -43,7 +42,7 @@ export function encryptPassword(password: string): string {
 
 // A namespace for creating v5 UUIDs
 const cdsNamespace = "0a69782c-f1af-48c5-9aaf-078a4e511518";
-function createV5(name: string): string {
+export function createV5(name: string): string {
   return v5(name, cdsNamespace);
 }
 


### PR DESCRIPTION
This PR updates the way that we create class codes to make them shorter. Previously we were using a v5 UUID; now we just create a random string of characters of the specified length (set to 6 by default).