### PR TITLE
Allow excluding the student's data from the class measurements

### DIFF
--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -208,7 +208,11 @@ export async function getStudentHubbleMeasurements(studentID: number): Promise<H
   });
 }
 
-async function getHubbleMeasurementsForStudentClass(studentID: number, classID: number, excludeWithNull: boolean = false): Promise<HubbleMeasurement[]> {
+async function getHubbleMeasurementsForStudentClass(studentID: number,
+                                                    classID: number,
+                                                    excludeWithNull: boolean = false,
+                                                    excludeStudent: boolean = false,
+): Promise<HubbleMeasurement[]> {
 
   const classIDs = await getMergedIDsForClass(classID);
 
@@ -224,6 +228,9 @@ async function getHubbleMeasurementsForStudentClass(studentID: number, classID: 
   }
 
   const measurementWhereConditions: WhereOptions<HubbleMeasurement> = [];
+  if (excludeStudent) {
+    measurementWhereConditions.push({ student_id: { [Op.ne]: studentID } });
+  }
   if (excludeWithNull) {
     measurementWhereConditions.push(EXCLUDE_MEASUREMENTS_WITH_NULL_CONDITION);
   }
@@ -362,8 +369,9 @@ export async function getClassMeasurements(studentID: number,
                                            classID: number,
                                            lastChecked: number | null = null,
                                            excludeWithNull: boolean = false,
+                                           excludeStudent: boolean = false,
 ): Promise<HubbleMeasurement[]> {
-  let data = await getHubbleMeasurementsForStudentClass(studentID, classID, excludeWithNull);
+  let data = await getHubbleMeasurementsForStudentClass(studentID, classID, excludeWithNull, excludeStudent);
   if (data.length > 0 && lastChecked != null) {
     const lastModified = Math.max(...data.map(meas => meas.last_modified.getTime()));
     if (lastModified <= lastChecked) {

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -342,6 +342,7 @@ router.get(["/class-measurements/:studentID/:classID", "/stage-3-data/:studentID
     lastChecked = null;
   }
   const completeOnly = (req.query.complete_only as string)?.toLowerCase() === "true";
+  const excludeStudent = (req.query.exclude_student as string)?.toLowerCase() === "true";
   const params = req.params;
   let studentID = parseInt(params.studentID);
   let classID = parseInt(params.classID);
@@ -367,7 +368,7 @@ router.get(["/class-measurements/:studentID/:classID", "/stage-3-data/:studentID
     return;
   }
 
-  const measurements = await getClassMeasurements(student.id, cls.id, lastChecked, completeOnly);
+  const measurements = await getClassMeasurements(student.id, cls.id, lastChecked, completeOnly, excludeStudent);
   res.status(200).json({
     student_id: studentID,
     class_id: classID,
@@ -394,7 +395,8 @@ router.get(["/class-measurements/:studentID", "stage-3-measurements/:studentID"]
     return;
   }
 
-  const measurements = await getClassMeasurements(studentID, cls.id);
+  const excludeStudent = (req.query.exclude_student as string)?.toLowerCase() === "true";
+  const measurements = await getClassMeasurements(studentID, cls.id, null, excludeStudent);
   res.status(200).json({
     student_id: studentID,
     class_id: null,


### PR DESCRIPTION
This PR adds the ability to exclude the current student's data from the class measurements returned by the `/class-measurements` endpoint. This is exposed via a query parameter; set `exclude_student=true` to remove their data from the response. This is useful in contexts like the demo, where everyone is logged on as the same user and we aren't storing their data in the database.