### PR TITLE
Add endpoints for storing data from planet parade story

### DIFF
--- a/src/stories/planet-parade/database.ts
+++ b/src/stories/planet-parade/database.ts
@@ -1,0 +1,93 @@
+import * as S from "@effect/schema/Schema";
+
+import { logger } from "../../logger";
+import { LatLonArray, OptionalInt, OptionalLatLonArray, UpdateAttributes } from "../../utils";
+
+import { PlanetParadeData } from "./models";
+import { CreationAttributes } from "sequelize";
+
+type PlanetParadeUpdateAttributes = UpdateAttributes<PlanetParadeData>;
+
+export const PlanetParadeEntry = S.struct({
+  user_uuid: S.string,
+  user_selected_search_locations: LatLonArray,
+  user_selected_search_locations_count: OptionalInt,
+  user_selected_map_locations: LatLonArray,
+  user_selected_map_locations_count: OptionalInt,
+  app_time_ms: OptionalInt,
+  info_time_ms: OptionalInt,
+});
+
+export const PlanetParadeUpdate = S.struct({
+  user_selected_search_locations: OptionalLatLonArray,
+  user_selected_map_locations: OptionalLatLonArray,
+  delta_app_time_ms: OptionalInt,
+  delta_info_time_ms: OptionalInt,
+});
+
+export type PlanetParadeEntryT = S.Schema.To<typeof PlanetParadeEntry>;
+export type PlanetParadeUpdateT = S.Schema.To<typeof PlanetParadeUpdate>;
+
+export async function submitPlanetParadeData(data: PlanetParadeEntryT): Promise<PlanetParadeData | null> {
+  logger.verbose(`Attempting to submit planet parade data for user ${data.user_uuid}`);
+
+  const dataWithCounts: CreationAttributes<PlanetParadeData> = {
+    ...data,
+    user_selected_search_locations_count: data.user_selected_search_locations_count ?? 0,
+    user_selected_map_locations_count: data.user_selected_map_locations_count ?? 0,
+  };
+
+  return PlanetParadeData.upsert(dataWithCounts).then(([item, _]) => item);
+}
+
+export async function getAllPlanetParadeData(): Promise<PlanetParadeData[]> {
+  return PlanetParadeData.findAll();
+}
+
+export async function getPlanetParadeData(userUUID: string): Promise<PlanetParadeData | null> {
+  return PlanetParadeData.findOne({
+    where: { user_uuid: userUUID }
+  });
+}
+
+export async function updatePlanetParadeData(userUUID: string, update: PlanetParadeUpdateT): Promise<PlanetParadeData | null> {
+  const data = await PlanetParadeData.findOne({ where: { user_uuid: userUUID } });
+  
+  if (data === null) {
+    const created = await PlanetParadeData.create({
+      user_uuid: userUUID,
+      user_selected_search_locations: update.user_selected_search_locations ?? [],
+      user_selected_search_locations_count: update.user_selected_search_locations?.length ?? 0,
+      user_selected_map_locations: update.user_selected_map_locations ?? [],
+      user_selected_map_locations_count: update.user_selected_search_locations?.length ?? 0,
+      app_time_ms: update.delta_app_time_ms ?? 0,
+      info_time_ms: update.delta_info_time_ms ?? 0,
+    });
+    return created;
+  }
+  
+  const dbUpdate: PlanetParadeUpdateAttributes = {};
+  if (update.user_selected_map_locations) {
+    const selected = data.user_selected_map_locations.concat(update.user_selected_map_locations);
+    dbUpdate.user_selected_map_locations = selected;
+    dbUpdate.user_selected_map_locations_count = selected.length;
+  }
+
+  if (update.user_selected_search_locations) {
+    const selected = data.user_selected_search_locations.concat(update.user_selected_search_locations);
+    dbUpdate.user_selected_search_locations = selected;
+    dbUpdate.user_selected_search_locations_count = selected.length;
+  }
+
+  if (update.delta_app_time_ms) {
+    dbUpdate.app_time_ms = data.app_time_ms + update.delta_app_time_ms;
+  }
+
+  if (update.delta_info_time_ms) {
+    dbUpdate.info_time_ms = data.info_time_ms + update.delta_info_time_ms;
+  }
+
+  const result = await data.update(dbUpdate).catch(_err => null);
+  return result;
+
+}

--- a/src/stories/planet-parade/main.ts
+++ b/src/stories/planet-parade/main.ts
@@ -1,0 +1,7 @@
+import { router, setup } from "./router";
+
+module.exports = {
+  path: "/planet-parade",
+  router,
+  setup,
+};

--- a/src/stories/planet-parade/models/index.ts
+++ b/src/stories/planet-parade/models/index.ts
@@ -1,0 +1,10 @@
+import { Sequelize } from "sequelize";
+import { PlanetParadeData, initializePlanetParadeDataModel } from "./planet_parade_data";
+
+export {
+  PlanetParadeData,
+};
+
+export function initializeModels(db: Sequelize) {
+  initializePlanetParadeDataModel(db);
+}

--- a/src/stories/planet-parade/models/planet_parade_data.ts
+++ b/src/stories/planet-parade/models/planet_parade_data.ts
@@ -1,0 +1,62 @@
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
+
+export class PlanetParadeData extends Model<InferAttributes<PlanetParadeData>, InferCreationAttributes<PlanetParadeData>> {
+  declare id: CreationOptional<number>;
+  declare user_uuid: string;
+  declare user_selected_search_locations: [number, number][];
+  declare user_selected_search_locations_count: number;
+  declare user_selected_map_locations: [number, number][];
+  declare user_selected_map_locations_count: number;
+  declare app_time_ms: CreationOptional<number>;
+  declare info_time_ms: CreationOptional<number>;
+  declare last_updated: CreationOptional<Date>;
+}
+
+export function initializePlanetParadeDataModel(sequelize: Sequelize) {
+  PlanetParadeData.init({
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    user_uuid: {
+      type: DataTypes.STRING,
+      unique: true,
+      allowNull: false
+    },
+    user_selected_search_locations: {
+      type: DataTypes.JSON,
+      allowNull: false
+    },
+    user_selected_search_locations_count: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    user_selected_map_locations: {
+      type: DataTypes.JSON,
+      allowNull: false
+    },
+    user_selected_map_locations_count: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    info_time_ms: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    },
+    app_time_ms: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    },
+    last_updated: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
+    }
+  }, {
+    sequelize,
+  });
+}

--- a/src/stories/planet-parade/router.ts
+++ b/src/stories/planet-parade/router.ts
@@ -1,0 +1,76 @@
+import * as S from "@effect/schema/Schema";
+import * as Either from "effect/Either";
+import { Express, Router } from "express";
+import { Sequelize } from "sequelize";
+
+import {
+  PlanetParadeEntry,
+  PlanetParadeUpdate,
+  getPlanetParadeData,
+  submitPlanetParadeData,
+  updatePlanetParadeData
+} from "./database";
+import { initializeModels } from "./models";
+
+export const router = Router();
+
+export function setup(_app: Express, db: Sequelize) {
+  initializeModels(db);
+}
+
+router.put("/data", async (req, res) => {
+  const data = req.body;
+  const maybe = S.decodeUnknownEither(PlanetParadeEntry)(data);
+
+  if (Either.isLeft(maybe)) {
+    res.status(400);
+    res.json({ error: "Malformed data submission" });
+    return;
+  }
+  
+  const response = await submitPlanetParadeData(maybe.right);
+  if (response === null) {
+    res.status(400);
+    res.json({ error: "Error creating planet parade entry" });
+    return;
+  }
+
+  res.json({ response });
+  
+});
+
+router.get("/data/:uuid", async (req, res) => {
+  const uuid = req.params.uuid as string;
+  const response = await getPlanetParadeData(uuid);
+  if (response === null) {
+    res.status(404).json({ error: "Specified user data does not exist" });
+    return;
+  }
+
+  res.json({ response });
+});
+
+router.patch("/data/:uuid", async (req, res) => {
+  const data = req.body;
+
+  const maybe = S.decodeUnknownEither(PlanetParadeUpdate)(data);
+  if (Either.isLeft(maybe)) {
+    res.status(400).json({ error: "Malformed update submission" });
+    return;
+  }
+
+  const uuid = req.params.uuid as string;
+  const current = await getPlanetParadeData(uuid);
+  if (current === null) {
+    res.status(404).json({ error: "Specified user data does not exist" });
+    return;
+  }
+
+  const response = await updatePlanetParadeData(uuid, maybe.right);
+  if (response === null) {
+    res.status(500).json({ error: "Error updating user data" });
+    return;
+  }
+  res.json({ response });
+
+});

--- a/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
+++ b/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE PlanetParadeData (
+    id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
+	user_uuid varchar(36) NOT NULL UNIQUE,
+    user_selected_search_locations JSON NOT NULL,
+    user_selected_map_locations JSON NOT NULL,
+    app_time_ms INT NOT NULL DEFAULT 0,
+    info_time_ms INT NOT NULL DEFAULT 0,
+    last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+
+    PRIMARY KEY(id),
+    INDEX(user_uuid)
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;

--- a/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
+++ b/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
@@ -2,10 +2,12 @@ CREATE TABLE PlanetParadeData (
     id int(11) UNSIGNED NOT NULL UNIQUE AUTO_INCREMENT,
 	user_uuid varchar(36) NOT NULL UNIQUE,
     user_selected_search_locations JSON NOT NULL,
+    user_selected_search_locations_count INT NOT NULL,
     user_selected_map_locations JSON NOT NULL,
+    user_selected_map_locations_count INT NOT NULL,
     app_time_ms INT NOT NULL DEFAULT 0,
     info_time_ms INT NOT NULL DEFAULT 0,
-    last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     PRIMARY KEY(id),
     INDEX(user_uuid)

--- a/src/stories/solar-eclipse-2024/database.ts
+++ b/src/stories/solar-eclipse-2024/database.ts
@@ -1,15 +1,12 @@
 import * as S from "@effect/schema/Schema";
-import { logger } from "../../logger";
 
-import { UpdateAttributes } from "../../utils";
+import { logger } from "../../logger";
+import { UpdateAttributes, LatLonArray, OptionalInt, OptionalLatLonArray } from "../../utils";
+
 import { SolarEclipse2024Data } from "./models";
+import { CreationAttributes } from "sequelize";
 
 type SolarEclipse2024UpdateAttributes = UpdateAttributes<SolarEclipse2024Data>;
-
-const LatLonArray = S.mutable(S.array(S.mutable(S.tuple(S.number, S.number))));
-const OptionalInt = S.optional(S.number.pipe(S.int()), { exact: true });
-const OptionalLatLonArray = S.optional(LatLonArray, { exact: true });
-
 
 export const SolarEclipse2024Entry = S.struct({
   user_uuid: S.string,
@@ -48,7 +45,7 @@ export type SolarEclipse2024UpdateT = S.Schema.To<typeof SolarEclipse2024Update>
 export async function submitSolarEclipse2024Data(data: SolarEclipse2024EntryT): Promise<SolarEclipse2024Data | null> {
   logger.verbose(`Attempting to submit solar eclipse 2024 measurement for user ${data.user_uuid}`);
 
-  const dataWithCounts = {
+  const dataWithCounts: CreationAttributes<SolarEclipse2024Data> = {
     ...data,
     advanced_weather_selected_locations_count: data.advanced_weather_selected_locations_count ?? 0,
     cloud_cover_selected_locations_count: data.cloud_cover_selected_locations_count ?? data.cloud_cover_selected_locations.length,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import { enc, SHA256 } from "crypto-js";
 import { v5 } from "uuid";
 
+import * as S from "@effect/schema/Schema";
 import { Model } from "sequelize";
 
 import { ParsedQs } from "qs";
@@ -31,6 +32,10 @@ export type Either<T, U> = Only<T,U> | Only<U,T>;
 export type Mutable<T> = {
   -readonly [P in keyof T]: T[P];
 }
+
+export const LatLonArray = S.mutable(S.array(S.mutable(S.tuple(S.number, S.number))));
+export const OptionalInt = S.optional(S.number.pipe(S.int()), { exact: true });
+export const OptionalLatLonArray = S.optional(LatLonArray, { exact: true });
 
 export function createVerificationCode(): string {
   return nanoid(21);


### PR DESCRIPTION
This PR adds a new sub-router for handling data from the planet parade story. The root path for these endpoints is `/planet-parade`. The structure is similar to the sub-router for the solar eclipse story:
* `PUT /data` will create a new entry from the body data, given that it has an appropriate schema
* `GET /data/<uuid>` gets the data for a given user, by their automatically assigned UUID
* `PATCH /data/<uuid>` allows updating a user's data