### PR TITLE
Add video information for planet parade

### DIFF
--- a/src/stories/planet-parade/database.ts
+++ b/src/stories/planet-parade/database.ts
@@ -16,6 +16,7 @@ export const PlanetParadeEntry = S.struct({
   user_selected_map_locations_count: OptionalInt,
   app_time_ms: OptionalInt,
   info_time_ms: OptionalInt,
+  video_time_ms: OptionalInt,
 });
 
 export const PlanetParadeUpdate = S.struct({
@@ -23,6 +24,7 @@ export const PlanetParadeUpdate = S.struct({
   user_selected_map_locations: OptionalLatLonArray,
   delta_app_time_ms: OptionalInt,
   delta_info_time_ms: OptionalInt,
+  delta_video_time_ms: OptionalInt,
 });
 
 export type PlanetParadeEntryT = S.Schema.To<typeof PlanetParadeEntry>;
@@ -62,6 +64,7 @@ export async function updatePlanetParadeData(userUUID: string, update: PlanetPar
       user_selected_map_locations_count: update.user_selected_search_locations?.length ?? 0,
       app_time_ms: update.delta_app_time_ms ?? 0,
       info_time_ms: update.delta_info_time_ms ?? 0,
+      video_time_ms: update.delta_video_time_ms ?? 0,
     });
     return created;
   }
@@ -79,12 +82,18 @@ export async function updatePlanetParadeData(userUUID: string, update: PlanetPar
     dbUpdate.user_selected_search_locations_count = selected.length;
   }
 
+  // For the time deltas, it's fine to skip the update logic whether 
+  // they're null/undefined (nothing to report) or zero (no change)
   if (update.delta_app_time_ms) {
     dbUpdate.app_time_ms = data.app_time_ms + update.delta_app_time_ms;
   }
 
   if (update.delta_info_time_ms) {
     dbUpdate.info_time_ms = data.info_time_ms + update.delta_info_time_ms;
+  }
+
+  if (update.delta_video_time_ms) {
+    dbUpdate.video_time_ms = data.video_time_ms + update.delta_video_time_ms;
   }
 
   const result = await data.update(dbUpdate).catch(_err => null);

--- a/src/stories/planet-parade/models/planet_parade_data.ts
+++ b/src/stories/planet-parade/models/planet_parade_data.ts
@@ -10,6 +10,8 @@ export class PlanetParadeData extends Model<InferAttributes<PlanetParadeData>, I
   declare app_time_ms: CreationOptional<number>;
   declare info_time_ms: CreationOptional<number>;
   declare video_time_ms: CreationOptional<number>;
+  declare video_opened: CreationOptional<boolean>;
+  declare video_played: CreationOptional<boolean>;
   declare last_updated: CreationOptional<Date>;
 }
 
@@ -54,6 +56,16 @@ export function initializePlanetParadeDataModel(sequelize: Sequelize) {
     },
     video_time_ms: {
       type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    },
+    video_opened: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: 0
+    },
+    video_played: {
+      type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: 0
     },

--- a/src/stories/planet-parade/models/planet_parade_data.ts
+++ b/src/stories/planet-parade/models/planet_parade_data.ts
@@ -9,6 +9,7 @@ export class PlanetParadeData extends Model<InferAttributes<PlanetParadeData>, I
   declare user_selected_map_locations_count: number;
   declare app_time_ms: CreationOptional<number>;
   declare info_time_ms: CreationOptional<number>;
+  declare video_time_ms: CreationOptional<number>;
   declare last_updated: CreationOptional<Date>;
 }
 
@@ -41,12 +42,17 @@ export function initializePlanetParadeDataModel(sequelize: Sequelize) {
       type: DataTypes.INTEGER,
       allowNull: false
     },
+    app_time_ms: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    },
     info_time_ms: {
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 0
     },
-    app_time_ms: {
+    video_time_ms: {
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 0

--- a/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
+++ b/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
@@ -7,6 +7,7 @@ CREATE TABLE PlanetParadeData (
     user_selected_map_locations_count INT NOT NULL,
     app_time_ms INT NOT NULL DEFAULT 0,
     info_time_ms INT NOT NULL DEFAULT 0,
+    video_time_ms INT NOT NULL DEFAULT 0,
     last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     PRIMARY KEY(id),

--- a/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
+++ b/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
@@ -8,6 +8,8 @@ CREATE TABLE PlanetParadeData (
     app_time_ms INT NOT NULL DEFAULT 0,
     info_time_ms INT NOT NULL DEFAULT 0,
     video_time_ms INT NOT NULL DEFAULT 0,
+    video_opened tinyint(1) NOT NULL DEFAULT 0,
+    video_played tinyint(1) NOT NULL DEFAULT 0,
     last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     PRIMARY KEY(id),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,7 @@ export type Mutable<T> = {
 
 export const LatLonArray = S.mutable(S.array(S.mutable(S.tuple(S.number, S.number))));
 export const OptionalInt = S.optional(S.number.pipe(S.int()), { exact: true });
+export const OptionalBoolean = S.optional(S.boolean, { exact: true });
 export const OptionalLatLonArray = S.optional(LatLonArray, { exact: true });
 
 export function createVerificationCode(): string {


### PR DESCRIPTION
This PR updates the planet parade logic to allow keeping track of whether the video has been opened and played, and if played then how long. This also updates the relevant SQL table definition.