### PR TITLE
Add tracking of WWT usage for planet parade

### DIFF
--- a/src/stories/planet-parade/models/planet_parade_data.ts
+++ b/src/stories/planet-parade/models/planet_parade_data.ts
@@ -12,6 +12,7 @@ export class PlanetParadeData extends Model<InferAttributes<PlanetParadeData>, I
   declare video_time_ms: CreationOptional<number>;
   declare video_opened: CreationOptional<boolean>;
   declare video_played: CreationOptional<boolean>;
+  declare created: CreationOptional<Date>;
   declare last_updated: CreationOptional<Date>;
   declare wwt_time_reset_count: CreationOptional<number>;
   declare wwt_reverse_count: CreationOptional<number>;
@@ -75,6 +76,11 @@ export function initializePlanetParadeDataModel(sequelize: Sequelize) {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: 0
+    },
+    created: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
     },
     last_updated: {
       type: DataTypes.DATE,

--- a/src/stories/planet-parade/models/planet_parade_data.ts
+++ b/src/stories/planet-parade/models/planet_parade_data.ts
@@ -13,6 +13,13 @@ export class PlanetParadeData extends Model<InferAttributes<PlanetParadeData>, I
   declare video_opened: CreationOptional<boolean>;
   declare video_played: CreationOptional<boolean>;
   declare last_updated: CreationOptional<Date>;
+  declare wwt_time_reset_count: CreationOptional<number>;
+  declare wwt_reverse_count: CreationOptional<number>;
+  declare wwt_play_pause_count: CreationOptional<number>;
+  declare wwt_speedups: CreationOptional<number[]>;
+  declare wwt_slowdowns: CreationOptional<number[]>;
+  declare wwt_rate_selections: CreationOptional<number[]>;
+  declare wwt_start_stop_times: CreationOptional<[number, number][]>;
 }
 
 export function initializePlanetParadeDataModel(sequelize: Sequelize) {
@@ -73,7 +80,42 @@ export function initializePlanetParadeDataModel(sequelize: Sequelize) {
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
-    }
+    },
+    wwt_time_reset_count: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      defaultValue: 0,
+    },
+    wwt_reverse_count: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      defaultValue: 0,
+    },
+    wwt_play_pause_count: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      defaultValue: 0,
+    },
+    wwt_speedups: {
+      type: DataTypes.JSON,
+      allowNull: false,
+      defaultValue: "[]",
+    },
+    wwt_slowdowns: {
+      type: DataTypes.JSON,
+      allowNull: false,
+      defaultValue: "[]",
+    },
+    wwt_rate_selections: {
+      type: DataTypes.JSON,
+      allowNull: false,
+      defaultValue: "[]",
+    },
+    wwt_start_stop_times: {
+      type: DataTypes.JSON,
+      allowNull: false,
+      defaultValue: "[]",
+    },
   }, {
     sequelize,
   });

--- a/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
+++ b/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
@@ -10,6 +10,7 @@ CREATE TABLE PlanetParadeData (
     video_time_ms INT NOT NULL DEFAULT 0,
     video_opened tinyint(1) NOT NULL DEFAULT 0,
     video_played tinyint(1) NOT NULL DEFAULT 0,
+    created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     wwt_time_reset_count int(11) UNSIGNED NOT NULL DEFAULT 0,
     wwt_reverse_count int(11) UNSIGNED NOT NULL DEFAULT 0,

--- a/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
+++ b/src/stories/planet-parade/sql/create_planet_parade_data_table.sql
@@ -11,6 +11,13 @@ CREATE TABLE PlanetParadeData (
     video_opened tinyint(1) NOT NULL DEFAULT 0,
     video_played tinyint(1) NOT NULL DEFAULT 0,
     last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    wwt_time_reset_count int(11) UNSIGNED NOT NULL DEFAULT 0,
+    wwt_reverse_count int(11) UNSIGNED NOT NULL DEFAULT 0,
+    wwt_play_pause_count int(11) UNSIGNED NOT NULL DEFAULT 0,
+    wwt_speedups JSON NOT NULL DEFAULT ("[]"),
+    wwt_slowdowns JSON NOT NULL DEFAULT ("[]"),
+    wwt_rate_selections JSON NOT NULL DEFAULT ("[]"),
+    wwt_start_stop_times JSON NOT NULL DEFAULT ("[]"),
 
     PRIMARY KEY(id),
     INDEX(user_uuid)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,10 +33,17 @@ export type Mutable<T> = {
   -readonly [P in keyof T]: T[P];
 }
 
+
 export const LatLonArray = S.mutable(S.array(S.mutable(S.tuple(S.number, S.number))));
+export const NumberPair = S.mutable(S.tuple(S.number, S.number));
+export const NumberArray = S.mutable(S.array(S.mutable(S.number)));
+export const NumberPairArray = S.mutable(S.array(NumberPair));
 export const OptionalInt = S.optional(S.number.pipe(S.int()), { exact: true });
 export const OptionalBoolean = S.optional(S.boolean, { exact: true });
 export const OptionalLatLonArray = S.optional(LatLonArray, { exact: true });
+export const OptionalNumberPair = S.optional(NumberPair, { exact: true });
+export const OptionalNumberArray = S.optional(NumberArray, { exact: true });
+export const OptionalNumberPairArray = S.optional(NumberPairArray, { exact: true });
 
 export function createVerificationCode(): string {
   return nanoid(21);


### PR DESCRIPTION
This PR is a server-side implementation of the functionality requested in https://github.com/cosmicds/planet-parade/issues/60. This primarily consists of model and endpoint updates to add in several new fields, which are:
* `wwt_time_reset_count`: How many times the user reset the WWT time
* `wwt_reverse_count`: How many times the user changed whether or not time is reversed
* `wwt_play_pause_count`: How many times the user pressed the play/pause button
* `wwt_speedups`: A list of numbers which records the time rate after each time the user presses the speedup button
* `wwt_slowdowns`: A list of numbers which records the time rate after each time the user presses the slowdown button
* `wwt_rate_selections`: A list of numbers which records time rates selected from the "More Speed Controls" option
* `wwt_start_stop_times`: The initial and final times on the WWT clock recorded between each update sent to the database. This isn't any sort of interval as these times are fundamentally unrelated.

Additionally, this adds an extra `created` field to each entry. This will be set once on the entry creation. Thus we have a sense of when the user first visited the app as well as the last time that their entry was updated.