### PR TITLE
Allow ignoring particular classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 /dist
 
 # local env files
+.env
 .env.local
 .env.*.local
 

--- a/src/associations.ts
+++ b/src/associations.ts
@@ -1,10 +1,13 @@
-import { Student } from "./models/student";
-import { Class } from "./models/class";
-import { Story } from "./models/story";
-import { StudentsClasses } from "./models/student_class";
-import { ClassStories } from "./models/story_class";
-import { StoryState } from "./models/story_state";
-import { IgnoreStudent } from "./models/ignore_student";
+import { 
+  Class,
+  ClassStories,
+  IgnoreClass,
+  IgnoreStudent,
+  Story,
+  StoryState,
+  Student,
+  StudentsClasses,
+} from "./models";
 
 export function setUpAssociations() {
 
@@ -74,10 +77,28 @@ export function setUpAssociations() {
     foreignKey: "student_id"
   });
 
+  Class.hasMany(IgnoreClass, {
+    foreignKey: "class_id"
+  });
+  IgnoreClass.belongsTo(Class, {
+    as: "class",
+    targetKey: "id",
+    foreignKey: "class_id"
+  });
+
   Story.hasMany(IgnoreStudent, {
     foreignKey: "story_name"
   });
   IgnoreStudent.belongsTo(Story, {
+    as: "story",
+    targetKey: "name",
+    foreignKey: "story_name"
+  });
+
+  Story.hasMany(IgnoreClass, {
+    foreignKey: "story_name"
+  });
+  IgnoreClass.belongsTo(Story, {
     as: "story",
     targetKey: "name",
     foreignKey: "story_name"
@@ -91,7 +112,6 @@ export function setUpAssociations() {
     targetKey: "name",
     foreignKey: "story_name"
   });
-
 
   Class.hasMany(ClassStories, {
     foreignKey: "class_id"

--- a/src/models/ignore_class.ts
+++ b/src/models/ignore_class.ts
@@ -1,0 +1,33 @@
+import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes } from "sequelize";
+import { Class } from "./class";
+import { Story } from "./story";
+
+export class IgnoreClass extends Model<InferAttributes<IgnoreClass>, InferCreationAttributes<IgnoreClass>> {
+  declare class_id: number;
+  declare story_name: string;
+}
+
+export function initializeIgnoreClassModel(sequelize: Sequelize) {
+  IgnoreClass.init({
+    class_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Class,
+        key: "id"
+      }
+    },
+    story_name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true,
+      references: {
+        model: Story,
+        key: "name"
+      }
+    }
+  }, {
+    sequelize,
+  });
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -2,6 +2,7 @@ import { Class, initializeClassModel } from "./class";
 import { DashboardClassGroup, initializeDashboardClassGroupModel } from "./dashboard_class_group";
 import { DummyClass, initializeDummyClassModel } from "./dummy_class";
 import { Educator, initializeEducatorModel } from "./educator";
+import { IgnoreClass, initializeIgnoreClassModel } from "./ignore_class";
 import { IgnoreStudent, initializeIgnoreStudentModel } from "./ignore_student";
 import { ClassStories, initializeClassStoryModel } from "./story_class";
 import { CosmicDSSession, initializeSessionModel } from "./session";
@@ -23,6 +24,7 @@ export {
   DashboardClassGroup,
   DummyClass,
   Educator,
+  IgnoreClass,
   IgnoreStudent,
   Stage,
   StageState,
@@ -45,6 +47,7 @@ export function initializeModels(db: Sequelize) {
   initializeStoryStateModel(db);
   initializeStudentClassModel(db);
   initializeStudentOptionsModel(db);
+  initializeIgnoreClassModel(db);
   initializeIgnoreStudentModel(db);
   initializeQuestionModel(db);
   initializeDashboardClassGroupModel(db);

--- a/src/sql/create_ignore_classes_table.sql
+++ b/src/sql/create_ignore_classes_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IgnoreClasses (
+    class_id int(11) UNSIGNED NOT NULL,
+    story_name varchar(50) NOT NULL,
+
+    PRIMARY KEY(class_id, story_name),
+    INDEX(class_id),
+    INDEX(story_name),
+    FOREIGN KEY(class_id)
+        REFERENCES Classes(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    FOREIGN KEY(story_name)
+        REFERENCES Stories(name)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;


### PR DESCRIPTION
This PR resolves #178 by implementing the scheme described there. At the database level, we create an `IgnoreClasses` table that allows us to specify a (class, story) pair so that we can know to ignore everything from the given class when fetching/calculating values for the given story.