### PR TITLE
Update student SQL to account for database change

### DIFF
--- a/src/models/student.ts
+++ b/src/models/student.ts
@@ -90,7 +90,7 @@ export function initializeStudentModel(sequelize: Sequelize) {
     last_visit: {
       type: DataTypes.DATE,
       allowNull: false,
-      defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
+      defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
     },
     last_visit_ip: {
       type: DataTypes.STRING

--- a/src/sql/create_student_table.sql
+++ b/src/sql/create_student_table.sql
@@ -13,7 +13,7 @@ CREATE TABLE Students (
     lon varchar(20) COLLATE utf8_unicode_ci,
     profile_created datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
     visits int(11) NOT NULL DEFAULT 0,
-    last_visit datetime NOT NULL,
+    last_visit datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
     last_visit_ip varchar(50) COLLATE utf8_unicode_ci,
     seed tinyint(2) NOT NULL DEFAULT 0,
     team_member varchar(30),


### PR DESCRIPTION
This is a tiny PR to update the SQL definition for the student table, as we've added a default value of `CURRENT_TIMESTAMP` for the `last_visit` column.