### PR TITLE
Add endpoints related to whether a story is active for a given class

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -827,7 +827,7 @@ export async function classSize(classID: number): Promise<number> {
   });
 }
 
-export async function classStoryActive(classID: number, storyName: string): Promise<boolean | null> {
+export async function isClassStoryActive(classID: number, storyName: string): Promise<boolean | null> {
   const classStory = await ClassStories.findOne({
     where: {
       class_id: classID,
@@ -836,6 +836,19 @@ export async function classStoryActive(classID: number, storyName: string): Prom
   });
   
   return classStory?.active ?? null;
+}
+
+export async function setClassStoryActive(classID: number, storyName: string, active: boolean): Promise<boolean> {
+  const result = await ClassStories.update(
+    { active  },
+    {
+      where: {
+        class_id: classID,
+        story_name: storyName,
+      }
+    }
+  );
+  return result[0] > 0;
 }
 
 export async function getStudentOptions(studentID: number): Promise<StudentOptions | null> {

--- a/src/database.ts
+++ b/src/database.ts
@@ -827,6 +827,17 @@ export async function classSize(classID: number): Promise<number> {
   });
 }
 
+export async function classStoryActive(classID: number, storyName: string): Promise<boolean | null> {
+  const classStory = await ClassStories.findOne({
+    where: {
+      class_id: classID,
+      story_name: storyName,
+    },
+  });
+  
+  return classStory?.active ?? null;
+}
+
 export async function getStudentOptions(studentID: number): Promise<StudentOptions | null> {
   return StudentOptions.findOne({ where: { student_id: studentID } }).catch((_error) => null);
 }

--- a/src/models/story_class.ts
+++ b/src/models/story_class.ts
@@ -5,7 +5,7 @@ import { Story } from "./story";
 export class ClassStories extends Model<InferAttributes<ClassStories>, InferCreationAttributes<ClassStories>> {
   declare class_id: number;
   declare story_name: string;
-  declare active: CreationOptional<number>;
+  declare active: CreationOptional<boolean>;
 }
 
 export function initializeClassStoryModel(sequelize: Sequelize) {
@@ -29,7 +29,7 @@ export function initializeClassStoryModel(sequelize: Sequelize) {
       }
     },
     active: {
-      type: DataTypes.TINYINT,
+      type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: 1,
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -647,6 +647,27 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
     res.json(students);
   });
 
+  app.get("/classes/active/:classID/:storyName", async (req, res) => {
+    const classID = Number(req.params.classID);
+    const cls = await findClassById(classID);
+    if (cls === null) {
+      res.status(404).json({
+        error: `No class found with ID ${classID}`,
+      });
+      return;
+    }
+    const storyName = req.params.storyName;
+    const story = await getStory(storyName);
+    if (story === null) {
+      res.status(404).json({
+        error: `No story found with name ${storyName}`,
+      });
+      return
+    }
+
+
+  });
+
   app.get("/story-state/:studentID/:storyName", async (req, res) => {
     const params = req.params;
     const studentID = Number(params.studentID);

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,8 @@ import {
   CreateClassSchema,
   QuestionInfoSchema,
   getClassRoster,
+  isClassStoryActive,
+  setClassStoryActive,
 } from "./database";
 
 import {
@@ -662,9 +664,78 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
       res.status(404).json({
         error: `No story found with name ${storyName}`,
       });
-      return
+      return;
     }
 
+    const active = await isClassStoryActive(classID, storyName);
+    if (active === null) {
+      res.status(404).json({
+        error: `It seems that class ${classID} is not signed up for story ${storyName}`,
+      });
+      return;
+    }
+
+    res.json({
+      active,
+    });
+
+  });
+
+  app.post("/classes/active/:classID/:storyName", async (req, res) => {
+    const classID = Number(req.params.classID);
+    const cls = await findClassById(classID);
+    if (cls === null) {
+      res.status(404).json({
+        error: `No class found with ID ${classID}`,
+      });
+      return;
+    }
+    const storyName = req.params.storyName;
+    const story = await getStory(storyName);
+    if (story === null) {
+      res.status(404).json({
+        error: `No story found with name ${storyName}`,
+      });
+      return;
+    }
+
+    const schema = S.struct({
+      active: S.boolean,
+    });
+    const maybe = S.decodeUnknownEither(schema)(req.body);
+    if (Either.isLeft(maybe)) {
+      res.status(400).json({
+        error: "Invalid request body; should have form { active: <boolean> }",
+      });
+      return;
+    }
+
+    const active = maybe.right.active;
+    let error = false;
+    const success = setClassStoryActive(classID, storyName, active)
+      .catch(_err => {
+        error = true;
+      });
+
+    if (error) {
+      res.status(500).json({
+        error: `There was an error updating the active status for class ID ${classID}, story ${storyName}`,
+      });
+      return;
+    }
+    if (!success) {
+      res.status(404).json({
+        error: `It seems that class ${classID} is not signed up for story ${storyName}`,
+      });
+      return;
+    }
+
+    res.json({
+      class_id: classID,
+      story_name: storyName,
+      active,
+      success: true,
+    });
 
   });
 


### PR DESCRIPTION
This PR adds two endpoints:
* `GET /classes/active/<class-id>/<story-name>` that returns whether or not the given story is active for the given class
* `POST /classes/active/<class-id>/<story-name>` - passing a body of the form `{active: <boolean>}` will set the class/story pair to be active if it exists