### PR TITLE
Return class size when getting class data

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -555,11 +555,13 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
       cls = await findClassById(id);
     }
 
+    const size = cls != null ? await classSize(cls.id) : 0;
     if (cls === null) {
       res.statusCode = 404;
     }
     res.json({
       class: cls,
+      size,
     });
   });
 

--- a/tests/classes.test.ts
+++ b/tests/classes.test.ts
@@ -48,6 +48,7 @@ describe("Test class routes", () => {
         .then((res) => {
           const resCls = res.body.class;
           expectToMatchModel(resCls, cls, ["created", "updated"]);
+          expect(res.body.size).toEqual(0);
         });
     }
     await cleanup();
@@ -62,6 +63,7 @@ describe("Test class routes", () => {
         .then((res) => {
           const resCls = res.body.class;
           expectToMatchModel(resCls, cls, ["created", "updated"]);
+          expect(res.body.size).toEqual(0);
         });
     }
     await cleanup();
@@ -74,6 +76,7 @@ describe("Test class routes", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         expect(res.body.class).toBeNull();
+        expect(res.body.size).toEqual(0);
       });
   });
 


### PR DESCRIPTION
This PR updates the `GET /classes/<identifier>` endpoint to include the class size.