### PR TITLE
Add endpoint to set student's ignored status

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -145,6 +145,16 @@ export async function findStudentById(id: number): Promise<Student | null> {
   });
 }
 
+// This is a very common operation, so we create a utility method for it
+export async function findStudentByIdOrUsername(identifier: string): Promise<Student | null> {
+  const id = Number(identifier);
+  if (isNaN(id)) {
+    return findStudentByUsername(identifier);
+  } else {
+    return findStudentById(id);
+  }
+}
+
 export async function findEducatorById(id: number): Promise<Educator | null> {
   return Educator.findOne({
     where: { id }

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,7 +58,7 @@ import {
   VerificationResult,
 } from "./request_results";
 
-import { CosmicDSSession, StudentsClasses, Class, Student, IgnoreStudent } from "./models";
+import { CosmicDSSession, StudentsClasses, Class, IgnoreStudent } from "./models";
 
 import { ParsedQs } from "qs";
 import express, { Express, Request, Response as ExpressResponse } from "express";

--- a/src/server.ts
+++ b/src/server.ts
@@ -444,8 +444,8 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
     const student = await findStudentByIdOrUsername(identifier);
     if (student === null) {
       res.status(404).json({
-        message: `No student found for identifier ${identifier}`,
         success: false,
+        error: `No student found for identifier ${identifier}`,
       });
       return;
     }
@@ -454,8 +454,8 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
     const story = await getStory(storyName);
     if (story === null) {
       res.status(404).json({
-        error: `No story found with name ${storyName}`,
         success: false,
+        error: `No story found with name ${storyName}`,
       });
       return;
     }
@@ -466,6 +466,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
     const maybe = S.decodeUnknownEither(schema)(req.body);
     if (Either.isLeft(maybe)) {
       res.status(400).json({
+        success: false,
         error: "Invalid request body; should have form { ignore: <boolean> }",
       });
       return;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -6,7 +6,7 @@ import type { Test } from "supertest";
 import type { InferAttributes, CreationAttributes, Model, Sequelize } from "sequelize";
 
 import { setUpAssociations } from "../src/associations";
-import { Educator, StageState, Story, StoryState, StudentsClasses, initializeModels } from "../src/models";
+import { Educator, IgnoreStudent, StageState, Story, StoryState, StudentsClasses, initializeModels } from "../src/models";
 import { createApp } from "../src/server";
 import { Class, Student } from "../src/models";
 import { APIKey } from "../src/models/api_key";
@@ -81,6 +81,7 @@ export async function syncTables(force=false): Promise<void> {
   await Story.sync(options);
   await StoryState.sync(options);
   await StageState.sync(options);
+  await IgnoreStudent.sync(options);
 }
 
 export async function addAPIKey(): Promise<APIKey | void> {


### PR DESCRIPTION
This PR adds a `PUT /students/ignore/<student identifier>/<story name>` endpoint that allows setting whether or not a student is ignored for a given story, via a body of the form `{ ignore: boolean }`.