### PR TITLE
Updates to student and class summary logic

### DIFF
--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -469,7 +469,7 @@ router.get("/all-data", async (req, res) => {
   const [measurements, studentData, classData] =
     await Promise.all([
       getAllHubbleMeasurements(before, minimal, classID),
-      getAllHubbleStudentData(before, minimal, classID),
+      getAllHubbleStudentData([], minimal),
       getAllHubbleClassData(before, minimal, classID)
     ]);
   res.json({

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -466,11 +466,26 @@ router.get("/all-data", async (req, res) => {
   }
   const beforeMs: number = parseInt(req.query.before as string);
   const before = isNaN(beforeMs) ? null : new Date(beforeMs);
-  const [measurements, studentData, classData] =
+  const classData = await getAllHubbleClassData(before, minimal, classID);
+  const classIDs = new Set(classData.map(data => data.class_id));
+  for (const id of classIDs) {
+    const mergedIDs = await getMergedIDsForClass(id, true);
+    mergedIDs.forEach(mid => {
+      if (!classIDs.has(mid)) {
+        classIDs.add(mid);
+      }
+    });
+  }
+
+  if (classID !== null) {
+    const merged = await getMergedIDsForClass(classID, true);
+    merged.forEach(mid => classIDs.delete(mid));
+  }
+
+  const [measurements, studentData] =
     await Promise.all([
       getAllHubbleMeasurements(before, minimal, classID),
-      getAllHubbleStudentData([], minimal),
-      getAllHubbleClassData(before, minimal, classID)
+      getAllHubbleStudentData([...classIDs], minimal),
     ]);
   res.json({
     measurements,


### PR DESCRIPTION
This PR makes a few updates to how the student and class summaries are served to the Hubble app, to take into account the fact that we've been "merging" classes together.

The SQL here is admittedly rather gnarly. I have some thoughts on things that we can do to clean this up, but this seems to work and we're under a bit of a time crunch so I'll push this for now and continue to tinker in the background.