### PR TITLE
TEMPO Lite usage tracking, part 2

### DIFF
--- a/src/stories/tempo-lite/database.ts
+++ b/src/stories/tempo-lite/database.ts
@@ -117,7 +117,7 @@ export async function updateTempoLiteData(userUUID: string, update: TempoLiteUpd
       share_button_clicked_count: update.delta_share_button_clicked_count ?? 0,
       play_clicked_count: update.delta_play_clicked_count ?? 0,
       time_slider_used_count: update.delta_time_slider_used_count ?? 0,
-      opacity_slider_used_count: update.opacity_slider_used_count ?? 0,
+      opacity_slider_used_count: update.delta_opacity_slider_used_count ?? 0,
       field_of_regard_toggled: update.field_of_regard_toggled ?? false,
       cloud_mask_toggled: update.cloud_mask_toggled ?? false,
       high_res_data_toggled: update.high_res_data_toggled ?? false,

--- a/src/stories/tempo-lite/database.ts
+++ b/src/stories/tempo-lite/database.ts
@@ -31,7 +31,7 @@ export const TempoLiteEntry = S.struct({
   share_button_clicked_count: OptionalInt,
   play_clicked_count: OptionalInt,
   time_slider_used_count: OptionalInt,
-  opacity_slider_used: OptionalBoolean,
+  opacity_slider_used_count: OptionalInt,
   field_of_regard_toggled: OptionalBoolean,
   cloud_mask_toggled: OptionalBoolean,
   high_res_data_toggled: OptionalBoolean,
@@ -59,7 +59,7 @@ export const TempoLiteUpdate = S.struct({
   delta_share_button_clicked_count: OptionalInt,
   delta_play_clicked_count: OptionalInt,
   delta_time_slider_used_count: OptionalInt,
-  opacity_slider_used: OptionalBoolean,
+  delta_opacity_slider_used_count: OptionalInt,
   field_of_regard_toggled: OptionalBoolean,
   cloud_mask_toggled: OptionalBoolean,
   high_res_data_toggled: OptionalBoolean,
@@ -115,6 +115,12 @@ export async function updateTempoLiteData(userUUID: string, update: TempoLiteUpd
       credits_opened_count: update.delta_credits_opened_count ?? 0,
       credits_open_time_ms: update.delta_credits_open_time_ms ?? 0,
       share_button_clicked_count: update.delta_share_button_clicked_count ?? 0,
+      play_clicked_count: update.delta_play_clicked_count ?? 0,
+      time_slider_used_count: update.delta_time_slider_used_count ?? 0,
+      opacity_slider_used_count: update.opacity_slider_used_count ?? 0,
+      field_of_regard_toggled: update.field_of_regard_toggled ?? false,
+      cloud_mask_toggled: update.cloud_mask_toggled ?? false,
+      high_res_data_toggled: update.high_res_data_toggled ?? false,
     });
     return created;
   }
@@ -164,6 +170,9 @@ export async function updateTempoLiteData(userUUID: string, update: TempoLiteUpd
     "credits_opened_count",
     "credits_open_time_ms",
     "share_button_clicked_count",
+    "play_clicked_count",
+    "time_slider_used_count",
+    "opacity_slider_used_count",
   ] as const;
 
   for (const key of numberEntryKeys) {
@@ -171,6 +180,20 @@ export async function updateTempoLiteData(userUUID: string, update: TempoLiteUpd
     const updateValue = update[updateKey];
     if (updateValue) {
       dbUpdate[key] = data[key] + updateValue;
+    }
+  }
+
+  // Here, note that a user can't ever "undo" these actions
+  const booleanEntryKeys = [
+    "field_of_regard_toggled",
+    "cloud_mask_toggled",
+    "high_res_data_toggled",
+  ] as const;
+
+  for (const key of booleanEntryKeys) {
+    const updateValue = update[key];
+    if (updateValue) {
+      dbUpdate[key] = true;
     }
   }
 

--- a/src/stories/tempo-lite/database.ts
+++ b/src/stories/tempo-lite/database.ts
@@ -4,7 +4,7 @@ import { logger } from "../../logger";
 
 import { TempoLiteData } from "./models";
 import { CreationAttributes } from "sequelize";
-import { OptionalInt, OptionalIntArray, OptionalStringArray, OptionalStringPairArray, UpdateAttributes } from "../../utils";
+import { OptionalBoolean, OptionalInt, OptionalIntArray, OptionalStringArray, OptionalStringPairArray, UpdateAttributes } from "../../utils";
 
 type TempoLiteDataUpdateAttributes = UpdateAttributes<TempoLiteData>;
 
@@ -29,6 +29,12 @@ export const TempoLiteEntry = S.struct({
   credits_opened_count: OptionalInt,
   credits_open_time_ms: OptionalInt,
   share_button_clicked_count: OptionalInt,
+  play_clicked_count: OptionalInt,
+  time_slider_used_count: OptionalInt,
+  opacity_slider_used: OptionalBoolean,
+  field_of_regard_toggled: OptionalBoolean,
+  cloud_mask_toggled: OptionalBoolean,
+  high_res_data_toggled: OptionalBoolean,
 });
 
 export const TempoLiteUpdate = S.struct({
@@ -51,6 +57,12 @@ export const TempoLiteUpdate = S.struct({
   delta_credits_opened_count: OptionalInt,
   delta_credits_open_time_ms: OptionalInt,
   delta_share_button_clicked_count: OptionalInt,
+  delta_play_clicked_count: OptionalInt,
+  delta_time_slider_used_count: OptionalInt,
+  opacity_slider_used: OptionalBoolean,
+  field_of_regard_toggled: OptionalBoolean,
+  cloud_mask_toggled: OptionalBoolean,
+  high_res_data_toggled: OptionalBoolean,
 });
 
 export type TempoLiteEntryT = S.Schema.To<typeof TempoLiteEntry>;

--- a/src/stories/tempo-lite/models/tempo_lite_data.ts
+++ b/src/stories/tempo-lite/models/tempo_lite_data.ts
@@ -22,6 +22,12 @@ export class TempoLiteData extends Model<InferAttributes<TempoLiteData>, InferCr
   declare credits_opened_count: CreationOptional<number>;
   declare credits_open_time_ms: CreationOptional<number>;
   declare share_button_clicked_count: CreationOptional<number>;
+  declare play_clicked_count: CreationOptional<number>;
+  declare time_slider_used_count: CreationOptional<number>;
+  declare opacity_slider_used: CreationOptional<boolean>;
+  declare field_of_regard_toggled: CreationOptional<boolean>;
+  declare cloud_mask_toggled: CreationOptional<boolean>;
+  declare high_res_data_toggled: CreationOptional<boolean>;
   declare last_updated: CreationOptional<Date>;
 }
 
@@ -113,6 +119,30 @@ export function initializeTempoLiteDataModel(sequelize: Sequelize) {
     share_button_clicked_count: {
       type: DataTypes.INTEGER.UNSIGNED,
       defaultValue: 0,
+    },
+    play_clicked_count: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      defaultValue: 0,
+    },
+    time_slider_used_count: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      defaultValue: 0,
+    },
+    opacity_slider_used: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    field_of_regard_toggled: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    cloud_mask_toggled: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    high_res_data_toggled: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
     },
     last_updated: {
       type: DataTypes.DATE,

--- a/src/stories/tempo-lite/models/tempo_lite_data.ts
+++ b/src/stories/tempo-lite/models/tempo_lite_data.ts
@@ -24,7 +24,7 @@ export class TempoLiteData extends Model<InferAttributes<TempoLiteData>, InferCr
   declare share_button_clicked_count: CreationOptional<number>;
   declare play_clicked_count: CreationOptional<number>;
   declare time_slider_used_count: CreationOptional<number>;
-  declare opacity_slider_used: CreationOptional<boolean>;
+  declare opacity_slider_used_count: CreationOptional<number>;
   declare field_of_regard_toggled: CreationOptional<boolean>;
   declare cloud_mask_toggled: CreationOptional<boolean>;
   declare high_res_data_toggled: CreationOptional<boolean>;
@@ -128,8 +128,8 @@ export function initializeTempoLiteDataModel(sequelize: Sequelize) {
       type: DataTypes.INTEGER.UNSIGNED,
       defaultValue: 0,
     },
-    opacity_slider_used: {
-      type: DataTypes.BOOLEAN,
+    opacity_slider_used_count: {
+      type: DataTypes.INTEGER.UNSIGNED,
       defaultValue: false,
     },
     field_of_regard_toggled: {

--- a/src/stories/tempo-lite/sql/create_tempo_lite_data_table.sql
+++ b/src/stories/tempo-lite/sql/create_tempo_lite_data_table.sql
@@ -22,7 +22,7 @@ CREATE TABLE TempoLiteData (
     share_button_clicked_count int(11) UNSIGNED NOT NULL DEFAULT 0,
     play_clicked_count int(11) UNSIGNED NOT NULL DEFAULT 0,
     time_slider_user_count int(11) UNSIGNED NOT NULL DEFAULT 0,
-    opacity_slider_used tinyint(1) UNSIGNED NOT NULL DEFAULT 0,
+    opacity_slider_used_count int(11) UNSIGNED NOT NULL DEFAULT 0,
     field_of_regard_toggled tinyint(1) UNSIGNED NOT NULL DEFAULT 0,
     cloud_mask_toggled tinyint(1) UNSIGNED NOT NULL DEFAULT 0,
     high_res_data_toggled tinyint(1) UNSIGNED NOT NULL DEFAULT 0,

--- a/src/stories/tempo-lite/sql/create_tempo_lite_data_table.sql
+++ b/src/stories/tempo-lite/sql/create_tempo_lite_data_table.sql
@@ -20,6 +20,12 @@ CREATE TABLE TempoLiteData (
     credits_opened_count int(11) UNSIGNED NOT NULL DEFAULT 0,
     credits_open_time_ms int(11) UNSIGNED NOT NULL DEFAULT 0,
     share_button_clicked_count int(11) UNSIGNED NOT NULL DEFAULT 0,
+    play_clicked_count int(11) UNSIGNED NOT NULL DEFAULT 0,
+    time_slider_user_count int(11) UNSIGNED NOT NULL DEFAULT 0,
+    opacity_slider_used tinyint(1) UNSIGNED NOT NULL DEFAULT 0,
+    field_of_regard_toggled tinyint(1) UNSIGNED NOT NULL DEFAULT 0,
+    cloud_mask_toggled tinyint(1) UNSIGNED NOT NULL DEFAULT 0,
+    high_res_data_toggled tinyint(1) UNSIGNED NOT NULL DEFAULT 0,
     last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     
     PRIMARY KEY(id),


### PR DESCRIPTION
This PR follows up on #195 by adding some additional fields to the TEMPO Lite tracking and updating the server to handle them.