### PR TITLE
Update class SQL/model

### DIFF
--- a/src/models/class.ts
+++ b/src/models/class.ts
@@ -11,6 +11,7 @@ export class Class extends Model<InferAttributes<Class>, InferCreationAttributes
   declare code: string;
   declare asynchronous: CreationOptional<boolean>;
   declare test: CreationOptional<boolean>;
+  declare seed: CreationOptional<boolean>;
   declare expected_size: CreationOptional<number>;
   declare small_class: CreationOptional<boolean>;
 }
@@ -63,6 +64,11 @@ export function initializeClassModel(sequelize: Sequelize) {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: 0
+    },
+    seed: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: 0,
     },
     expected_size: {
       type: DataTypes.INTEGER.UNSIGNED,

--- a/src/sql/create_class_table.sql
+++ b/src/sql/create_class_table.sql
@@ -7,6 +7,7 @@ CREATE TABLE Classes (
     code varchar(50) NOT NULL UNIQUE,
     asynchronous tinyint(1) NOT NULL DEFAULT 0,
     test tinyint(1) NOT NULL DEFAULT 0,
+    seed tinyint(1) NOT NULL DEFAULT 0,
     updated datetime DEFAULT NULL,
     expected_size int(11) UNSIGNED NOT NULL,
     small_class tinyint(1) GENERATED ALWAYS AS (expected_size < 15) VIRTUAL,


### PR DESCRIPTION
This PR updates the SQL and Sequelize model for the classes table to reflect a change in the database schema - in particular, the addition of a `seed` column that indicates whether a class is a seed data class.