### PR TITLE
Add state patching endpoint

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -501,19 +501,23 @@ export async function updateStoryState(studentID: number, storyName: string, new
   return result?.story_state ?? null;
 }
 
-function patchState(state: Record<string,any>, patch: Record<string,any>, rootKey?: string) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function patchState(state: Record<string,any>, patch: Record<string,any>) {
   Object.entries(patch).forEach(([key, value]) => {
-    const isObject = typeof value === 'object' && !Array.isArray(value) && value !== null;
-    const fullKey = rootKey ? `${rootKey}:${key}` : key;
+    const isObject = typeof value === "object" && !Array.isArray(value) && value !== null;
     if (isObject) {
-      patchState(state, patch, fullKey);
+      if (!(key in state)) {
+        state[key] = value;
+      } else {
+        patchState(state[key], value);
+      }
     } else {
       state[key] = value;
     }
   });
 }
 
-export async function patchStoryState(studentID: number, storyName: string, patch: JSON) {
+export async function patchStoryState(studentID: number, storyName: string, patch: JSON): Promise<JSON | null> {
   const query = {
     student_id: studentID,
     story_name: storyName,
@@ -527,12 +531,14 @@ export async function patchStoryState(studentID: number, storyName: string, patc
   });
 
   if (result !== null) {
-    patchState(result, patch);
-    const storyData = { ...query, story_state: result.story_state };
-    result?.update(storyData).catch(error => {
-      console.log(error);
-      return null;
-    });
+    const state = result.story_state;
+    patchState(state, patch);
+    // TODO: For some reason, doing a regular `await result.update({ story_state: state })...`
+    // did not produce an update to the database. Something about how JSON-type fields are handled?
+    // Until we figure this out, just force-update
+    result.story_state = state;
+    result.changed("story_state", true);
+    await result.save();
   } else {
     const storyData = { ...query, story_state: patch };
     result = await StoryState.create(storyData).catch(error => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,6 +50,7 @@ import {
   findClassByIdOrCode,
   findStudentByIdOrUsername,
   addVisitForStory,
+  patchStoryState,
 } from "./database";
 
 import {
@@ -824,6 +825,20 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
     const storyName = params.storyName;
     const newState = req.body;
     const state = await updateStoryState(studentID, storyName, newState);
+    const status = state !== null ? 200 : 404;
+    res.status(status).json({
+      student_id: studentID,
+      story_name: storyName,
+      state
+    });
+  });
+
+  app.patch("/story-state/:studentID/:storyName", async (req, res) => {
+    const params = req.params;
+    const studentID = Number(params.studentID);
+    const storyName = params.storyName;
+    const patch = req.body;
+    const state = await patchStoryState(studentID, storyName, patch);
     const status = state !== null ? 200 : 404;
     res.status(status).json({
       student_id: studentID,

--- a/tests/story-states.test.ts
+++ b/tests/story-states.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
-import { beforeAll, afterAll, describe, it, expect } from "@jest/globals";
+import { beforeAll, afterAll, describe, it } from "@jest/globals";
 import request from "supertest";
 import type { Sequelize } from "sequelize";
 import type { Express } from "express";
 
 import { authorize, createTestApp, getTestDatabaseConnection, randomClassForEducator, randomEducator, randomStory, randomStudent } from "./utils";
-import { Student, StageState, StoryState, StudentsClasses } from "../src/models";
+import { Student, StoryState, StudentsClasses } from "../src/models";
 
 async function setupStoryAndStudentStates() {
   const story = await randomStory();
@@ -29,6 +29,7 @@ async function setupStoryAndStudentStates() {
       a: 1,
       b: "x",
       flag: true,
+      arr: [1, 2, 3],
     } as unknown as JSON,
   });
   const storyState2 = await StoryState.create({
@@ -38,6 +39,7 @@ async function setupStoryAndStudentStates() {
       a: 5,
       b: "y",
       flag: false,
+      arr: [2, 4],
     } as unknown as JSON,
   });
 
@@ -79,7 +81,7 @@ describe("Test story state routes", () => {
     testDB.close();
   });
 
-  it("Should return the stage states for a given student & story", async () => {
+  it("Should return the story state for a given student & story", async () => {
     const { story, student1, student2, storyState1, storyState2, cleanup } = await setupStoryAndStudentStates();
 
     const studentsAndStories: [Student, StoryState][] = [[student1, storyState1], [student2, storyState2]];
@@ -142,6 +144,33 @@ describe("Test story state routes", () => {
         student_id: student1.id,
         story_name: story.name,
         state: newStoryState,
+      });
+
+    await cleanup();
+  });
+
+  it("Should correctly patch the story state", async () => {
+    const { story, student1, cleanup } = await setupStoryAndStudentStates();
+
+    const patch = {
+      a: 2,
+      b: "w",
+      arr: { "0": 6, "3": 5 },
+    };
+
+    await authorize(request(testApp).patch(`/story-state/${student1.id}/${story.name}`))
+      .send(patch)
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .expect({
+        student_id: student1.id,
+        story_name: story.name,
+        state: {
+          a: 2,
+          b: "w",
+          flag: true,
+          arr: [6, 2, 3, 5],
+        }
       });
 
     await cleanup();

--- a/tests/story-states.test.ts
+++ b/tests/story-states.test.ts
@@ -150,16 +150,16 @@ describe("Test story state routes", () => {
   });
 
   it("Should correctly patch the story state", async () => {
-    const { story, student1, cleanup } = await setupStoryAndStudentStates();
+    const { story, student1, student2, cleanup } = await setupStoryAndStudentStates();
 
-    const patch = {
+    const patch1 = {
       a: 2,
       b: "w",
       arr: { "0": 6, "3": 5 },
     };
 
     await authorize(request(testApp).patch(`/story-state/${student1.id}/${story.name}`))
-      .send(patch)
+      .send(patch1)
       .expect(200)
       .expect("Content-Type", /json/)
       .expect({
@@ -170,6 +170,28 @@ describe("Test story state routes", () => {
           b: "w",
           flag: true,
           arr: [6, 2, 3, 5],
+        }
+      });
+
+    const patch2 = {
+      arr: { "1" : 7 },
+      c: "test",
+      flag: true,
+    };
+
+    await authorize(request(testApp).patch(`/story-state/${student2.id}/${story.name}`))
+      .send(patch2)
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .expect({
+        student_id: student2.id,
+        story_name: story.name,
+        state: {
+          a: 5,
+          b: "y",
+          flag: true,
+          arr: [2, 7],
+          c: "test",
         }
       });
 


### PR DESCRIPTION
This PR adds an endpoint `PATCH /story-state/<student ID>/<story name>`. The body of this request should be a JSON object representing the "diff" of the previous and current story states. The idea of this is to decrease network traffic, both outgoing from client(s) and incoming here, as currently we expect the client to send a `PUT` request whose body is the entire state.

CC @nmearl 