### PR TITLE
Add simple routers for stories

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { promises } from "fs";
 import { join } from "path";
 import { createApp } from "./server";
 import { getDatabaseConnection } from "./database";
+import { storyRouter } from "./story_router";
 
 
 const STORIES_DIR = join(__dirname, "stories");
@@ -24,6 +25,15 @@ promises.readdir(STORIES_DIR, { withFileTypes: true }).then(entries => {
 .catch(error => {
   console.error(error);
   throw new Error("Error setting up sub-routers!");
+});
+
+const stories = [
+  "blaze-star-nova", "radwave-in-motion", "radwave-in-motion-deutsch",
+  "jwst-brick", "pinwheel-supernova", "green-comet",
+];
+stories.forEach(story => {
+  const router = storyRouter(story);
+  app.use(`/${story}`, router);
 });
 
 // set port, listen for requests


### PR DESCRIPTION
This PR adds simple routers that (currently) only contain the `/user-experience` endpoints for the stories that don't currently have a router. These simple routers are built using the `storyRouter` utility added in #209.