### PR TITLE
Change type of selected location in Seasons

### DIFF
--- a/src/stories/seasons/database.ts
+++ b/src/stories/seasons/database.ts
@@ -2,7 +2,7 @@ import * as S from "@effect/schema/Schema";
 
 import { SeasonsData } from "./models";
 import { logger } from "../../logger";
-import { OptionalInt, OptionalNumberArray, OptionalNumberPair, OptionalString, OptionalStringArray, UpdateAttributes } from "../../utils";
+import { OptionalInt, OptionalNumberArray, OptionalNumberPair, OptionalNumberPairArray, OptionalString, OptionalStringArray, UpdateAttributes } from "../../utils";
 import { CreationAttributes } from "sequelize";
 
 type SeasonsDataUpdateAttributes = UpdateAttributes<SeasonsData>;
@@ -11,7 +11,7 @@ export const SeasonsUpdate = S.struct({
   app_time_ms: OptionalInt,
   user_selected_dates: OptionalStringArray,
   user_selected_dates_count: OptionalInt,
-  user_selected_locations: OptionalStringArray,
+  user_selected_locations: OptionalNumberPairArray,
   user_selected_locations_count: OptionalInt,
   wwt_rate_selections: OptionalNumberArray,
   wwt_start_stop_times: OptionalNumberPair,

--- a/src/stories/seasons/models/seasons_data.ts
+++ b/src/stories/seasons/models/seasons_data.ts
@@ -5,7 +5,7 @@ export class SeasonsData extends Model<InferAttributes<SeasonsData>, InferCreati
   declare user_uuid: string;
   declare user_selected_dates: CreationOptional<string[]>;
   declare user_selected_dates_count: CreationOptional<number>;
-  declare user_selected_locations: CreationOptional<string[]>;
+  declare user_selected_locations: CreationOptional<[number, number][]>;
   declare user_selected_locations_count: CreationOptional<number>;
   declare aha_moment_response: CreationOptional<string>;
   declare last_updated: CreationOptional<Date>;


### PR DESCRIPTION
This PR changes the user selected locations in the Seasons story from being an array of strings to an array of lat/lon pairs.