### PR TITLE
Update time slider used count for Seasons

### DIFF
--- a/src/stories/seasons/database.ts
+++ b/src/stories/seasons/database.ts
@@ -104,6 +104,7 @@ export async function updateSeasonsData(userUUID: string, update: SeasonsUpdateT
   // See comment above about skipping the update logic
   // if deltas are either null/undefined or zero
   const numberEntryKeys = [
+    "time_slider_used_count",
     "wwt_play_pause_count",
     "wwt_time_reset_count",
     "wwt_reverse_count",


### PR DESCRIPTION
Another issue noticed while testing - the time slider used counter for the Seasons story isn't updated when the request is handled. This PR should fix that.