### PR TITLE
Add endpoint for getting merged student information

### DIFF
--- a/src/stories/hubbles_law/associations.ts
+++ b/src/stories/hubbles_law/associations.ts
@@ -89,7 +89,7 @@ export function setUpHubbleAssociations() {
   });
 
   HubbleClassStudentMerge.belongsTo(Student, {
-    as: "merge",
+    as: "student",
     targetKey: "id",
     foreignKey: "student_id",
   });
@@ -98,7 +98,7 @@ export function setUpHubbleAssociations() {
   });
 
   HubbleClassStudentMerge.belongsTo(Class, {
-    as: "merge",
+    as: "class",
     targetKey: "id",
     foreignKey: "class_id",
   });

--- a/src/stories/hubbles_law/associations.ts
+++ b/src/stories/hubbles_law/associations.ts
@@ -1,5 +1,5 @@
 import { Class, Student, StudentsClasses } from "../../models";
-import { Galaxy, HubbleMeasurement, SampleHubbleMeasurement, SyncMergedHubbleClasses } from "./models";
+import { Galaxy, HubbleClassStudentMerge, HubbleMeasurement, SampleHubbleMeasurement, SyncMergedHubbleClasses } from "./models";
 import { AsyncMergedHubbleStudentClasses } from "./models/async_merged_student_classes";
 import { HubbleClassData } from "./models/hubble_class_data";
 import { HubbleStudentData } from "./models/hubble_student_data";
@@ -86,6 +86,24 @@ export function setUpHubbleAssociations() {
     as: "class",
     targetKey: "id",
     foreignKey: "class_id"
+  });
+
+  HubbleClassStudentMerge.belongsTo(Student, {
+    as: "merge",
+    targetKey: "id",
+    foreignKey: "student_id",
+  });
+  Student.hasMany(HubbleClassStudentMerge, {
+    foreignKey: "student_id",
+  });
+
+  HubbleClassStudentMerge.belongsTo(Class, {
+    as: "merge",
+    targetKey: "id",
+    foreignKey: "class_id",
+  });
+  Class.hasMany(HubbleClassStudentMerge, {
+    foreignKey: "class_id",
   });
 
 }

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -63,7 +63,7 @@ import { Sequelize, ForeignKeyConstraintError, UniqueConstraintError } from "seq
 import { classForStudentStory, findClassById, findStudentById } from "../../database";
 import { HubbleClassStudentMerge, HubbleMeasurement, initializeModels } from "./models";
 import { setUpHubbleAssociations } from "./associations";
-import { Story } from "../../models";
+import { ClassStories, Story } from "../../models";
 import { Schema } from "@effect/schema";
 
 import { OAS3Options } from "swagger-jsdoc";
@@ -1392,6 +1392,88 @@ router.put("/merge-students", async (req, res) => {
   }
 
 });
+
+/*
+ * @openapi
+ *  /merge-students/{classID}:
+ *    get:
+ *      tags:
+ *        - classes
+ *      description: Return a list of information about the students merged into a given class
+ *      parameters:
+ *        - name: classID
+ *          in: path
+ *          required: true
+ *          schema:
+ *            type: integer
+ *        - name: full
+ *          in: query
+ *          required: false
+ *          schema:
+ *            type: boolean
+ *            default: false
+ *      responses:
+ *        200:
+ *          description: The class exists. If `full` is true, this is a list of `Student` objects; otherwise this is a list of student IDs
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  students:
+ *                    type: array
+ *                    schema:
+ *                      items:
+ *                        oneOf:
+ *                          - $ref: "#/components/schemas/Student"
+ *                          - $ref: integer
+ *        404:
+ *          description: The class does not exist
+ *          content:
+ *            application/json:
+ *              schema:
+ *               $ref: "#/components/schemas/Error"
+ *        422:
+ *          description: The class exists but is not signed up for Hubble's Law
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: "#/components/schemas/Error"
+ */
+router.get("/merge-students/:classID", async (req, res) => {
+  const classID = Number(req.params.classID);
+  const cls = await findClassById(classID);
+  if (cls == null) {
+    res.status(404).json({
+      error: `No class exists with ID ${classID}`,
+    });
+    return;
+  }
+
+  const signedUp = await ClassStories.findOne({
+    where: {
+      class_id: classID,
+      story_name: "hubbles_law",
+    }
+  });
+  if (signedUp == null) {
+    res.status(422).json({
+      error: `The class with ID ${classID} is not signed up for Hubble's Law`,
+    });
+    return;
+  }
+
+  const mergedStudents = await HubbleClassStudentMerge.findAll({
+    where: {
+      class_id: classID,
+    }
+  });
+
+  res.json({
+    students: mergedStudents,
+  });
+});
+
 
 /**
  *  @openapi

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -63,7 +63,7 @@ import { Sequelize, ForeignKeyConstraintError, UniqueConstraintError } from "seq
 import { classForStudentStory, findClassById, findStudentById } from "../../database";
 import { HubbleClassStudentMerge, HubbleMeasurement, initializeModels } from "./models";
 import { setUpHubbleAssociations } from "./associations";
-import { ClassStories, Story } from "../../models";
+import { ClassStories, Story, Student } from "../../models";
 import { Schema } from "@effect/schema";
 
 import { OAS3Options } from "swagger-jsdoc";
@@ -1463,14 +1463,19 @@ router.get("/merge-students/:classID", async (req, res) => {
     return;
   }
 
-  const mergedStudents = await HubbleClassStudentMerge.findAll({
-    where: {
-      class_id: classID,
-    }
+  const full = (req.query.full as string)?.toLowerCase() === "true";
+
+  const mergedStudents = await Student.findAll({
+    include: [{
+      model: HubbleClassStudentMerge,
+      where: {
+        class_id: classID,
+      }
+    }],
   });
 
   res.json({
-    students: mergedStudents,
+    students: full ? mergedStudents : mergedStudents.map(student => student.id),
   });
 });
 

--- a/src/stories/hubbles_law/router.ts
+++ b/src/stories/hubbles_law/router.ts
@@ -1393,8 +1393,8 @@ router.put("/merge-students", async (req, res) => {
 
 });
 
-/*
- * @openapi
+/**
+ *  @openapi
  *  /merge-students/{classID}:
  *    get:
  *      tags:

--- a/src/stories/hubbles_law/tests/student_class_merge.test.ts
+++ b/src/stories/hubbles_law/tests/student_class_merge.test.ts
@@ -5,10 +5,10 @@ import request, { Response } from "supertest";
 import type { Express } from "express";
 import { Op, type Sequelize } from "sequelize";
 
-import { authorize, createTestApp, getTestDatabaseConnection, createRandomClassWithStudents, randomStudent, randomBetween, randomClassForEducator } from "../../../../tests/utils";
+import { authorize, createTestApp, getTestDatabaseConnection, createRandomClassWithStudents, randomStudent, randomBetween, randomClassForEducator, expectToMatchModel } from "../../../../tests/utils";
 import { HubbleClassStudentMerge } from "../models/hubble_class_student_merges";
 import { globalRoutePath, createRandomHubbleDataForStudent, createRandomHubbleMeasurementForStudent, createRandomGalaxies } from "./utils";
-import { Class, Educator, IgnoreStudent, Student } from "../../../models";
+import { Class, ClassStories, Educator, IgnoreStudent, Student } from "../../../models";
 import { HubbleMeasurement, HubbleStudentData } from "../models";
 import { addStudentToClass, findClassByIdOrCode } from "../../../database";
 import { mergeStudentIntoClass } from "../database";
@@ -54,6 +54,10 @@ describe("Test student/class merge functionality", () => {
     }
 
     const otherClass = await randomClassForEducator(educator.id);
+
+    // Sign the classes up for the Hubble's Law story
+    await ClassStories.create({ class_id: cls.id, story_name: "hubbles_law" });
+    await ClassStories.create({ class_id: otherClass.id, story_name: "hubbles_law" });
 
     studentsToMerge = [];
     studentsToNotMerge = [];
@@ -213,4 +217,69 @@ describe("Test student/class merge functionality", () => {
 
     await HubbleClassStudentMerge.destroy({ where: { student_id: { [Op.in]: studentIDs } } });
   });
+
+  it("Should return the list of student IDs merged into a given class", async () => {
+    const route = globalRoutePath(`/merge-students/${cls.id}`);
+
+    await authorize(request(testApp).get(route))
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .then(async res => {
+        const body = res.body;
+        const mergedStudentIDs = body.students;
+        expect(Array.isArray(mergedStudentIDs)).toEqual(true);
+        expect(mergedStudentIDs.length).toEqual(mergedCount);
+
+        expect(mergedStudentIDs.sort()).toEqual(studentsToMerge.map(student => student.id).sort());
+
+      });
+  });
+
+  it("Should return the list of student JSON merged into a given class", async () => {
+
+    const route = globalRoutePath(`/merge-students/${cls.id}?full=true`);
+    await authorize(request(testApp).get(route))
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .then(async res => {
+        const body = res.body;
+        const mergedStudents = body.students;
+        expect(Array.isArray(mergedStudents)).toEqual(true);
+        expect(mergedStudents.length).toEqual(mergedCount);
+
+        const studentsComparator = (s1: Student, s2: Student) => s1.id - s2.id;
+        mergedStudents.sort(studentsComparator);
+        for (let i = 0; i < mergedCount; i++) {
+          expectToMatchModel(mergedStudents[i], studentsToMerge[i], ["profile_created", "last_visit"]);
+        }
+      });
+  });
+
+  it("Should return a 404 if requesting merge students or a class that doesn't exist", async () => {
+    const badID = -1;
+    const route = globalRoutePath(`/merge-students/${badID}`);
+    await authorize(request(testApp).get(route))
+      .expect(404)
+      .expect("Content-Type", /json/)
+      .then(res => {
+        const error = res.body.error;
+        expect(typeof error).toEqual("string");
+        expect(error).toEqual(`No class exists with ID ${badID}`);
+      });
+  });
+
+  it("Should return a 422 if the class hasn't been signed up for Hubble's Law", async () => {
+    const data = await createRandomClassWithStudents(classSize);
+    const cls = data.class;
+    const route = globalRoutePath(`/merge-students/${cls.id}`);
+    await authorize(request(testApp).get(route))
+      .expect(422)
+      .expect("Content-Type", /json/)
+      .then(res => {
+        const error = res.body.error;
+        expect(typeof error).toEqual("string");
+        expect(error).toEqual(`The class with ID ${cls.id} is not signed up for Hubble's Law`);
+      });
+  });
+
 });


### PR DESCRIPTION
This PR adds a `GET /hubbles_law/merge-students/{classID}` endpoint for getting information about the students merged into a given class. The response body has a `students` field - by default this is a list of student IDs, but using a query of `full=true`, a list of JSON objects describing the students is returned.