### PR TITLE
Remove .ebextensions directory

### DIFF
--- a/.ebextensions/ts_compile.config
+++ b/.ebextensions/ts_compile.config
@@ -1,6 +1,0 @@
-# ts_compile.config
-container_commands:
-  compile:
-    command: "./node_modules/.bin/tsc -p tsconfig.json"
-    env:
-      PATH: /usr/bin/


### PR DESCRIPTION
We've moved from Elastic Beanstalk to Elastic Container Service on AWS, so we no longer need the `.ebextensions` directory.