### PR TITLE
Move OpenAPI spec test into script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,22 +48,5 @@ jobs:
           DB_NAME: test
           CDS_API_KEY: TEST_API_KEY
         run: |
-          mysql -u ${DB_USERNAME} -p"${DB_PASSWORD}" -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME};"
-          mysql -u ${DB_USERNAME} -p"${DB_PASSWORD}" ${DB_NAME} < src/sql/create_story_table.sql
-
-          npm run start &
-          sleep 10  # Give the app time to start up
-          specs=("" "/hubbles_law")
-          for spec in "${specs[@]}"; do
-            url="http://localhost:8080${spec}/docs.json"
-            echo $url
-            DATA=$(curl $url)
-            RESULT=$(curl -X "POST" \
-              -H "Content-Type: application/json" \
-              -d "$DATA" \
-              https://validator.swagger.io/validator/debug)
-            echo $RESULT
-            echo $RESULT | jq -e '. == {}'
-          done 
-          pkill -f node
-          mysql -u ${DB_USERNAME} -p"${DB_PASSWORD}" -e "DROP DATABASE ${DB_NAME};"
+          chmod +x scripts/test_openapi_specs.sh
+          scripts/test_openapi_specs.sh ${DB_USERNAME} ${DB_PASSWORD} ${DB_NAME} ${DB_HOSTNAME}

--- a/scripts/test_openapi_specs.sh
+++ b/scripts/test_openapi_specs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+export DB_USERNAME=${1:-"root"}
+export DB_PASSWORD=${2:-"root"}
+export DB_NAME=${3:-"test"}
+export DB_HOSTNAME=${4:-"127.0.0.1"}
+
+mysql -u ${DB_USERNAME} -p"${DB_PASSWORD}" -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME};"
+mysql -u ${DB_USERNAME} -p"${DB_PASSWORD}" ${DB_NAME} < src/sql/create_story_table.sql
+
+npm run start &
+sleep 10  # Give the app time to start up
+specs=("" "/hubbles_law")
+for spec in "${specs[@]}"; do
+  url="http://localhost:8080${spec}/docs.json"
+  echo $url
+  DATA=$(curl $url)
+  RESULT=$(curl -X "POST" \
+    -H "Content-Type: application/json" \
+    -d "$DATA" \
+    https://validator.swagger.io/validator/debug)
+  echo $RESULT
+  echo $RESULT | jq -e '. == {}'
+done 
+pkill -f node
+mysql -u ${DB_USERNAME} -p"${DB_PASSWORD}" -e "DROP DATABASE ${DB_NAME};"


### PR DESCRIPTION
In order to better facilitate running the checks locally, this PR moves the OpenAPI spec validation commands into a bash script.