### PR TITLE
Add endpoint for getting stories for class

### DIFF
--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -1,5 +1,5 @@
 import type { OAS3Definition } from "swagger-jsdoc";
-import { Class, Educator, Stage, StageState, StoryState, Student } from "../models";
+import { Class, ClassStories, Educator, Stage, StageState, StoryState, Student } from "../models";
 import { modelToSchema } from "./utils";
 import { Question } from "../models/question";
 
@@ -14,6 +14,7 @@ export function schemas(): Schemas {
     StageState: modelToSchema(StageState),
     StoryState: modelToSchema(StoryState),
     Question: modelToSchema(Question),
+    ClassStories: modelToSchema(ClassStories),
     User: {
       schema: {
         oneOf: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,7 +62,7 @@ import {
   VerificationResult,
 } from "./request_results";
 
-import { CosmicDSSession, StudentsClasses, Class, IgnoreStudent } from "./models";
+import { CosmicDSSession, StudentsClasses, Class, IgnoreStudent, ClassStories } from "./models";
 
 import { ParsedQs } from "qs";
 import express, { Express, Request, Response as ExpressResponse } from "express";
@@ -1568,6 +1568,52 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
       active,
     });
 
+  });
+
+  /**
+   *  @openapi
+   *  /classes/{classIdentifier}/stories:
+   *    get:
+   *      tags:
+   *        - classes
+   *        - stories
+   *      description: Get the stories associated with a given class, including whether each is active or not
+   *      parameters:
+   *        - name: classIdentifier
+   *          in: path
+   *          required: true
+   *          schema:
+   *            oneOf:
+   *              - type: string
+   *              - type: integer
+   *      responses:
+   *        200:
+   *          description: Returns a list whose entries give the story name and active status for each story associated with the given class
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: array
+   *                items:
+   *                  $ref: "#/components/schemas/ClassStories"
+   *        404:
+   *          description: No class exists with the given ID
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: "#/components/schemas/Error"
+   */
+  app.get("/classes/:classIdentifier/stories", async (req, res) => {
+    const classIdentifier = req.params.classIdentifier;
+    const cls = await findClassByIdOrCode(classIdentifier);
+    if (cls === null) {
+      res.status(404).json({
+        error: `No class found: ${classIdentifier}`,
+      });
+      return;
+    }
+
+    const stories = await ClassStories.findAll({ where: { class_id: cls.id } });
+    res.json({ stories });
   });
 
   /**

--- a/tests/class-stories.test.ts
+++ b/tests/class-stories.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
-import { beforeAll, afterAll, describe, it } from "@jest/globals";
+import { beforeAll, afterAll, describe, it, expect } from "@jest/globals";
 import request from "supertest";
 import type { Sequelize } from "sequelize";
 import type { Express } from "express";
@@ -17,6 +17,7 @@ async function setupClassesWithStories() {
   const story2 = await randomStory();
   const story3 = await randomStory();
   const stories = [story1, story2, story3];
+  console.log(stories);
 
   const cs1 = await ClassStories.create({ class_id: cls.id, story_name: story1.name, active: true });
   const cs2 = await ClassStories.create({ class_id: cls.id, story_name: story2.name, active: true });
@@ -49,8 +50,9 @@ describe("Test class-story routes", () => {
   });
 
   it("Should return the correct story information for the given class", async () => {
-    const { class: cls, classStories, cleanup } = await setupClassesWithStories();
+    const { class: cls, stories, classStories, cleanup } = await setupClassesWithStories();
     const identifiers = [cls.id, cls.code];
+    const storyNames = stories.map(story => story.name);
 
     for (const idf of identifiers) {
       await authorize(request(testApp).get(`/classes/${idf}/stories`))
@@ -58,7 +60,14 @@ describe("Test class-story routes", () => {
         .expect("Content-Type", /json/)
         .then(res => {
           const resStories = res.body.stories as Record<string, unknown>[];
-          resStories.forEach((story, index) => expectToMatchModel(story, classStories[index]));
+          resStories.forEach(story => {
+            // We don't know what the order of the stories returned from the endpoint will be
+            // nor do we expect to.
+            // So we just need to make sure that we compare against the correct model
+            expect(story).toHaveProperty("story_name");
+            const index = storyNames.indexOf(story.story_name as string);
+            expectToMatchModel(story, classStories[index]);
+          });
         });
     }
 

--- a/tests/class-stories.test.ts
+++ b/tests/class-stories.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
+import { beforeAll, afterAll, describe, it } from "@jest/globals";
+import request from "supertest";
+import type { Sequelize } from "sequelize";
+import type { Express } from "express";
+
+import { authorize, createTestApp, expectToMatchModel, getTestDatabaseConnection, randomClassForEducator, randomEducator, randomStory } from "./utils";
+import { setupApp } from "../src/app";
+import { ClassStories } from "../src/models";
+
+async function setupClassesWithStories() {
+  const educator = await randomEducator();
+  const cls = await randomClassForEducator(educator.id, { expected_size: 4 });
+
+  const story1 = await randomStory();
+  const story2 = await randomStory();
+  const story3 = await randomStory();
+  const stories = [story1, story2, story3];
+
+  const cs1 = await ClassStories.create({ class_id: cls.id, story_name: story1.name, active: true });
+  const cs2 = await ClassStories.create({ class_id: cls.id, story_name: story2.name, active: true });
+  const cs3 = await ClassStories.create({ class_id: cls.id, story_name: story3.name, active: false });
+  const classStories = [cs1, cs2, cs3];
+
+  const cleanup = async () => {
+    await cs1?.destroy();
+    await cs2?.destroy();
+    await cs3?.destroy();
+    await cls?.destroy();
+    await educator?.destroy();
+  };
+
+  return { educator, class: cls, stories, classStories, cleanup };
+}
+
+describe("Test class-story routes", () => {
+
+  let testDB: Sequelize;
+  let testApp: Express;
+  beforeAll(async () => {
+    testDB = await getTestDatabaseConnection();
+    testApp = await createTestApp(testDB);
+    setupApp(testApp, testDB);
+  });
+  
+  afterAll(async () => {
+    testDB.close();
+  });
+
+  it("Should return the correct story information for the given class", async () => {
+    const { class: cls, classStories, cleanup } = await setupClassesWithStories();
+    const identifiers = [cls.id, cls.code];
+
+    for (const idf of identifiers) {
+      await authorize(request(testApp).get(`/classes/${idf}/stories`))
+        .expect(200)
+        .expect("Content-Type", /json/)
+        .then(res => {
+          const resStories = res.body.stories as Record<string, unknown>[];
+          resStories.forEach((story, index) => expectToMatchModel(story, classStories[index]));
+        });
+    }
+
+    await cleanup();
+  });
+
+  it("Should return a 404 for a missing class", async () => {
+    const badID = -1;
+    await authorize(request(testApp).get(`/classes/${badID}/stories`))
+      .expect(404)
+      .expect("Content-Type", /json/);
+  });
+
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -10,6 +10,7 @@ import { InferAttributes, CreationAttributes, Model, Sequelize, UniqueConstraint
 import { setUpAssociations } from "../src/associations";
 import {
   APIKeyRole,
+  ClassStories,
   Educator,
   IgnoreClass,
   IgnoreStudent,
@@ -97,6 +98,7 @@ export async function syncTables(force=false): Promise<void> {
   await APIKeyRole.sync(options);
   await StudentsClasses.sync(options);
   await Story.sync(options);
+  await ClassStories.sync(options);
   await StoryState.sync(options);
   await StageState.sync(options);
   await IgnoreStudent.sync(options);


### PR DESCRIPTION
This PR adds a `GET` /classes/<identifier>/stories` endpoint that returns the class/story information (class ID, story name, active status) for each story that is associated with the given class.