### PR TITLE
Only use active classes for some endpoints

### DIFF
--- a/src/associations.ts
+++ b/src/associations.ts
@@ -1,5 +1,6 @@
 import { 
-    APIKeyRole,
+  APIKeyRole,
+  ActiveClass,
   Class,
   ClassStories,
   IgnoreClass,
@@ -34,6 +35,26 @@ export function setUpAssociations() {
     onUpdate: "CASCADE",
     onDelete: "CASCADE"
   });
+
+  Student.belongsToMany(ActiveClass, {
+    through: StudentsClasses,
+    sourceKey: "id",
+    targetKey: "id",
+    foreignKey: "student_id",
+    otherKey: "class_id",
+    onUpdate: "CASCADE",
+    onDelete: "CASCADE"
+  });
+  ActiveClass.belongsToMany(Student, {
+    through: StudentsClasses,
+    sourceKey: "id",
+    targetKey: "id",
+    foreignKey: "class_id",
+    otherKey: "student_id",
+    onUpdate: "CASCADE",
+    onDelete: "CASCADE"
+  });
+
 
   Story.belongsToMany(Class, {
     through: ClassStories,

--- a/src/associations.ts
+++ b/src/associations.ts
@@ -17,25 +17,6 @@ import { APIKey } from "./models/api_key";
 
 export function setUpAssociations() {
 
-  Student.belongsToMany(Class, {
-    through: StudentsClasses,
-    sourceKey: "id",
-    targetKey: "id",
-    foreignKey: "student_id",
-    otherKey: "class_id",
-    onUpdate: "CASCADE",
-    onDelete: "CASCADE"
-  });
-  Class.belongsToMany(Student, {
-    through: StudentsClasses,
-    sourceKey: "id",
-    targetKey: "id",
-    foreignKey: "class_id",
-    otherKey: "student_id",
-    onUpdate: "CASCADE",
-    onDelete: "CASCADE"
-  });
-
   Student.belongsToMany(ActiveClass, {
     through: StudentsClasses,
     sourceKey: "id",
@@ -55,6 +36,24 @@ export function setUpAssociations() {
     onDelete: "CASCADE"
   });
 
+  Student.belongsToMany(Class, {
+    through: StudentsClasses,
+    sourceKey: "id",
+    targetKey: "id",
+    foreignKey: "student_id",
+    otherKey: "class_id",
+    onUpdate: "CASCADE",
+    onDelete: "CASCADE"
+  });
+  Class.belongsToMany(Student, {
+    through: StudentsClasses,
+    sourceKey: "id",
+    targetKey: "id",
+    foreignKey: "class_id",
+    otherKey: "student_id",
+    onUpdate: "CASCADE",
+    onDelete: "CASCADE"
+  });
 
   Story.belongsToMany(Class, {
     through: ClassStories,

--- a/src/database.ts
+++ b/src/database.ts
@@ -651,16 +651,18 @@ export async function deleteStageState(studentID: number, storyName: string, sta
   });
 }
 
-export async function getClassesForEducator(educatorID: number): Promise<Class[]> {
-  return Class.findAll({
+export async function getClassesForEducator(educatorID: number, activeOnly=true): Promise<Class[]> {
+  const model = activeOnly ? ActiveClass : Class;
+  return model.findAll({
     where: {
       educator_id: educatorID
     }
   });
 }
 
-export async function getClassesForStudent(studentID: number): Promise<Class[]> {
-  return Class.findAll({
+export async function getClassesForStudent(studentID: number, activeOnly=true): Promise<Class[]> {
+  const model = activeOnly ? ActiveClass : Class;
+  return model.findAll({
     include: [{
       model: Student,
       where: {

--- a/src/database.ts
+++ b/src/database.ts
@@ -683,30 +683,41 @@ export async function getStudentsForClass(classID: number): Promise<Student[]> {
   });
 }
 
+export async function deactivateClass(cls: Class): Promise<Class> {
+  return cls.update({ active: false });
+}
+
+export async function deactiveClassByID(id: number): Promise<boolean> {
+  return Class.update({ active: false }, { where: { id } })
+    .then(result => result[0] > 0);
+}
+
 export async function deleteClass(id: number): Promise<number> {
   return Class.destroy({
     where: { id }
   });
 }
 
-export async function findClassByCode(code: string): Promise<Class | null> {
-  return Class.findOne({
+export async function findClassByCode(code: string, activeOnly=false): Promise<Class | null> {
+  const model = activeOnly ? ActiveClass : Class;
+  return model.findOne({
     where: { code }
   });
 }
 
-export async function findClassById(id: number): Promise<Class | null> {
-  return Class.findOne({
+export async function findClassById(id: number, activeOnly=false): Promise<Class | null> {
+  const model = activeOnly ? ActiveClass : Class;
+  return model.findOne({
     where: { id }
   });
 }
 
-export async function findClassByIdOrCode(identifier: string): Promise<Class | null> {
+export async function findClassByIdOrCode(identifier: string, activeOnly=false): Promise<Class | null> {
   const id = Number(identifier);
   if (isNaN(id)) {
-    return findClassByCode(identifier);
+    return findClassByCode(identifier, activeOnly);
   } else {
-    return findClassById(id);
+    return findClassById(id, activeOnly);
   }
 }
 
@@ -918,7 +929,7 @@ export async function isClassStoryActive(classID: number, storyName: string): Pr
 
 export async function setClassStoryActive(classID: number, storyName: string, active: boolean): Promise<boolean> {
   const result = await ClassStories.update(
-    { active  },
+    { active },
     {
       where: {
         class_id: classID,

--- a/src/database.ts
+++ b/src/database.ts
@@ -5,6 +5,7 @@ import { createNamespace } from "cls-hooked";
 import * as S from "@effect/schema/Schema";
 
 import {
+  ActiveClass,
   Class,
   Educator,
   ClassStories,

--- a/src/models/active_class.ts
+++ b/src/models/active_class.ts
@@ -1,4 +1,4 @@
-import { Class, CLASS_ATTRIBUTES, classOptions } from "./class";
+import { Class, CLASS_ATTRIBUTES } from "./class";
 import { Sequelize } from "sequelize";
 
 // NB: This model is actually a view defined on the Classes table
@@ -6,5 +6,5 @@ import { Sequelize } from "sequelize";
 export class ActiveClass extends Class {}
 
 export function initializeActiveClassModel(sequelize: Sequelize) {
-  ActiveClass.init(CLASS_ATTRIBUTES, classOptions(sequelize));
+  ActiveClass.init(CLASS_ATTRIBUTES, { sequelize });
 }

--- a/src/models/active_class.ts
+++ b/src/models/active_class.ts
@@ -1,0 +1,10 @@
+import { Class, CLASS_ATTRIBUTES, classOptions } from "./class";
+import { Sequelize } from "sequelize";
+
+// NB: This model is actually a view defined on the Classes table
+// where `active = 1`
+export class ActiveClass extends Class {}
+
+export function initializeActiveClassModel(sequelize: Sequelize) {
+  ActiveClass.init(CLASS_ATTRIBUTES, classOptions(sequelize));
+}

--- a/src/models/class.ts
+++ b/src/models/class.ts
@@ -91,17 +91,13 @@ export const CLASS_ATTRIBUTES = {
   },
 };
 
-export function classOptions(sequelize: Sequelize) {
-  return {
+export function initializeClassModel(sequelize: Sequelize) {
+  Class.init(CLASS_ATTRIBUTES, {
     sequelize,
     indexes: [
       {
         fields: ["code"],
       }
     ]
-  };
-}
-
-export function initializeClassModel(sequelize: Sequelize) {
-  Class.init(CLASS_ATTRIBUTES, classOptions(sequelize));
+  });
 }

--- a/src/models/class.ts
+++ b/src/models/class.ts
@@ -1,7 +1,7 @@
 import { Educator } from "./educator";
 import { Sequelize, DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from "sequelize";
 
-const CLASS_STATUS_VALUES = ["seed", "real_good_data", "real_bad_data", "test_good_data", "test_bad_data"] as const;
+export const CLASS_STATUS_VALUES = ["seed", "real_good_data", "real_bad_data", "test_good_data", "test_bad_data"] as const;
 type ClassStatus = typeof CLASS_STATUS_VALUES[number];
 
 export class Class extends Model<InferAttributes<Class>, InferCreationAttributes<Class>> {
@@ -20,82 +20,88 @@ export class Class extends Model<InferAttributes<Class>, InferCreationAttributes
   declare status: CreationOptional<ClassStatus>;
 }
 
-export function initializeClassModel(sequelize: Sequelize) {
-  Class.init({
-    id: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false,
-      autoIncrement: true,
-      primaryKey: true
-    },
-    name: {
-      type: DataTypes.STRING,
-      allowNull: false
-    },
-    educator_id: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false,
-      references: {
-        model: Educator,
-        key: "id"
-      }
-    },
-    created: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
-    },
-    updated: {
-      type: DataTypes.DATE,
-      allowNull: true,
-      defaultValue: null
-    },
-    active: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false
-    },
-    code: {
-      type: DataTypes.STRING,
-      allowNull: false
-    },
-    asynchronous: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false
-    },
-    test: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: 0
-    },
-    seed: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: 0,
-    },
-    expected_size: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false,
-    },
-    small_class: {
-      type: DataTypes.VIRTUAL,
-      // type: "tinyint(1) GENERATED ALWAYS AS (expected_size < 15) VIRTUAL",
-      get() {
-        return this.expected_size < 15; 
-      }
-    },
-    status: {
-      type: DataTypes.ENUM(...CLASS_STATUS_VALUES),
-      allowNull: true,
-      defaultValue: null,
-    },
-  }, {
+export const CLASS_ATTRIBUTES = {
+  id: {
+    type: DataTypes.INTEGER.UNSIGNED,
+    allowNull: false,
+    autoIncrement: true,
+    primaryKey: true
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  educator_id: {
+    type: DataTypes.INTEGER.UNSIGNED,
+    allowNull: false,
+    references: {
+      model: Educator,
+      key: "id"
+    }
+  },
+  created: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    defaultValue: Sequelize.literal("CURRENT_TIMESTAMP")
+  },
+  updated: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    defaultValue: null
+  },
+  active: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
+  },
+  code: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  asynchronous: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
+  },
+  test: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: 0
+  },
+  seed: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: 0,
+  },
+  expected_size: {
+    type: DataTypes.INTEGER.UNSIGNED,
+    allowNull: false,
+  },
+  small_class: {
+    type: DataTypes.VIRTUAL,
+    // type: "tinyint(1) GENERATED ALWAYS AS (expected_size < 15) VIRTUAL",
+    get() {
+      return this.expected_size < 15; 
+    }
+  },
+  status: {
+    type: DataTypes.ENUM(...CLASS_STATUS_VALUES),
+    allowNull: true,
+    defaultValue: null,
+  },
+};
+
+export function classOptions(sequelize: Sequelize) {
+  return {
     sequelize,
     indexes: [
       {
         fields: ["code"],
       }
     ]
-  });
+  };
+}
+
+export function initializeClassModel(sequelize: Sequelize) {
+  Class.init(CLASS_ATTRIBUTES, classOptions(sequelize));
 }

--- a/src/models/class.ts
+++ b/src/models/class.ts
@@ -16,7 +16,7 @@ export class Class extends Model<InferAttributes<Class>, InferCreationAttributes
   declare test: CreationOptional<boolean>;
   declare seed: CreationOptional<boolean>;
   declare expected_size: CreationOptional<number>;
-  declare small_class: CreationOptional<boolean>;
+  declare readonly small_class: CreationOptional<boolean>;
   declare status: CreationOptional<ClassStatus>;
 }
 
@@ -80,7 +80,7 @@ export const CLASS_ATTRIBUTES = {
   small_class: {
     type: DataTypes.VIRTUAL,
     // type: "tinyint(1) GENERATED ALWAYS AS (expected_size < 15) VIRTUAL",
-    get() {
+    get(this: Class): boolean {
       return this.expected_size < 15; 
     }
   },

--- a/src/models/class.ts
+++ b/src/models/class.ts
@@ -52,7 +52,7 @@ export const CLASS_ATTRIBUTES = {
   active: {
     type: DataTypes.BOOLEAN,
     allowNull: false,
-    defaultValue: false
+    defaultValue: true,
   },
   code: {
     type: DataTypes.STRING,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,6 @@
 import { APIKeyRole, initializeAPIKeyRoleModel } from "./api_key_role";
 import { Class, initializeClassModel } from "./class";
+import { ActiveClass, initializeActiveClassModel } from "./active_class";
 import { DashboardClassGroup, initializeDashboardClassGroupModel } from "./dashboard_class_group";
 import { DummyClass, initializeDummyClassModel } from "./dummy_class";
 import { Educator, initializeEducatorModel } from "./educator";
@@ -26,6 +27,7 @@ import { initializeUserExperienceRatingModel } from "./user_experience";
 export {
   APIKeyRole,
   Class,
+  ActiveClass,
   ClassStories,
   CosmicDSSession,
   DashboardClassGroup,
@@ -54,6 +56,7 @@ export function initializeModels(db: Sequelize) {
   initializeSessionModel(db);
   initializeEducatorModel(db);
   initializeClassModel(db);
+  initializeActiveClassModel(db);
   initializeStudentModel(db);
   initializeStoryModel(db);
   initializeClassStoryModel(db);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2177,6 +2177,10 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
    *          required: true
    *          schema:
    *            type: integer
+   *        - name: active_only
+   *          in: query
+   *          schema:
+   *            type: boolean
    *      responses:
    *        200:
    *          description: The given educator exists. Returns an object containing the educator ID and a list of Class objects 
@@ -2200,6 +2204,8 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
    */
   app.get("/educator-classes/:educatorID", async (req, res) => {
     const params = req.params;
+    const activeString = req.query.active as string | undefined;
+    const active = activeString?.toLowerCase() === "true";
     const educatorID = Number(params.educatorID);
     const educator = await findEducatorById(educatorID);
     if (educator === null) {
@@ -2208,7 +2214,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
       });
       return;
     }
-    const classes = await getClassesForEducator(educatorID);
+    const classes = await getClassesForEducator(educatorID, active);
     res.json({
       educator_id: educatorID,
       classes,

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import {
   updateStageState,
   deleteStageState,
   findClassById,
+  deactivateClass,
   getStages,
   getStory,
   getStageStates,
@@ -1225,7 +1226,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
       return;
     }
 
-    cls.update({ active: false })
+    deactivateClass(cls)
       .then(() => res.status(204).end())
       .catch(error => {
         console.log(error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1225,7 +1225,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
       return;
     }
 
-    cls.destroy()
+    cls.update({ active: false })
       .then(() => res.status(204).end())
       .catch(error => {
         console.log(error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2205,8 +2205,8 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
    */
   app.get("/educator-classes/:educatorID", async (req, res) => {
     const params = req.params;
-    const activeString = req.query.active as string | undefined;
-    const active = activeString?.toLowerCase() === "true";
+    const activeOnlyString = req.query.active_only as string | undefined;
+    const activeOnly = activeOnlyString?.toLowerCase() !== "false";
     const educatorID = Number(params.educatorID);
     const educator = await findEducatorById(educatorID);
     if (educator === null) {
@@ -2215,7 +2215,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
       });
       return;
     }
-    const classes = await getClassesForEducator(educatorID, active);
+    const classes = await getClassesForEducator(educatorID, activeOnly);
     res.json({
       educator_id: educatorID,
       classes,
@@ -2236,6 +2236,10 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
    *          required: true
    *          schema:
    *            type: integer
+   *        - name: active_only
+   *          in: query
+   *          schema:
+   *            type: boolean
    *      responses:
    *        200:
    *          description: Returns an object containing the student ID, as well as a list of Class items, one for each of the student's classes
@@ -2259,8 +2263,10 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
    */
   app.get("/student-classes/:studentID", async (req, res) => {
     const params = req.params;
+    const activeOnlyString = req.query.active_only as string | undefined;
+    const activeOnly = activeOnlyString?.toLowerCase() !== "false";
     const studentID = Number(params.studentID);
-    const classes = await getClassesForStudent(studentID);
+    const classes = await getClassesForStudent(studentID, activeOnly);
     res.json({
       student_id: studentID,
       classes: classes

--- a/src/sql/create_active_class_view.sql
+++ b/src/sql/create_active_class_view.sql
@@ -1,0 +1,4 @@
+CREATE VIEW ActiveClasses AS
+SELECT *
+FROM Classes
+WHERE active = 1;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -76,7 +76,7 @@ export async function setupTestDatabase(): Promise<Sequelize> {
   // See https://github.com/sequelize/sequelize/issues/7953
   // and https://stackoverflow.com/a/45114507
   // db.sync({ force: true, match: /test/ }).finally(() => db.close());
-  await syncTables();
+  await syncTables(db);
 
   return db;
 }
@@ -86,7 +86,7 @@ export async function teardownTestDatabase(): Promise<void> {
   await connection.query("DROP DATABASE test;");
 }
 
-export async function syncTables(force=false): Promise<void> {
+export async function syncTables(db: Sequelize, force=false): Promise<void> {
   const options = { force, alter: false };
   await APIKey.sync(options);
   await Student.sync(options);
@@ -103,6 +103,15 @@ export async function syncTables(force=false): Promise<void> {
   await StageState.sync(options);
   await IgnoreStudent.sync(options);
   await IgnoreClass.sync(options);
+
+  // ActiveClasses is a view, which Sequelize is not great at handling
+  // so we just create it ourselves here
+  await db.query(`
+    CREATE VIEW ActiveClasses AS
+    SELECT *
+    FROM Classes
+    WHERE active = 1;
+  `);
 }
 
 export async function addAdminAPIKey(): Promise<APIKey | void> {


### PR DESCRIPTION
This PR updates adds in the definition of `ActiveClass`. This corresponds to a SQL view which is defined in the database as all of the entries in the `Class` table where `active = 1`.

The main changes here where we use active classes:
* The `DELETE /classes/<identifier>` endpoint now no longer actually deletes the class in the database, it only marks it as inactive
* By default, the list of classes returned for students and educators only uses active classes