### PR TITLE
Set educator verified datatype as boolean

### DIFF
--- a/src/models/educator.ts
+++ b/src/models/educator.ts
@@ -32,7 +32,7 @@ export function initializeEducatorModel(sequelize: Sequelize) {
       unique: true
     },
     verified: {
-      type: DataTypes.TINYINT,
+      type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: 0
     },


### PR DESCRIPTION
This fixes an issue that was causing the `verified` field to not be included in the OpenAPI schema.