### PR TITLE
Update story-state endpoints to return StoryState objects

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -494,7 +494,7 @@ export async function updateStoryState(studentID: number, storyName: string, new
     return null;
   });
 
-  const storyData = { ...query, story_state: newState };
+  const storyData = { ...query, state: newState };
   if (result !== null) {
     result?.update(storyData).catch(error => {
       console.log(error);
@@ -539,16 +539,16 @@ export async function patchStoryState(studentID: number, storyName: string, patc
   });
 
   if (result !== null) {
-    const state = result.story_state;
+    const state = result.state;
     patchState(state, patch);
-    // TODO: For some reason, doing a regular `await result.update({ story_state: state })...`
+    // TODO: For some reason, doing a regular `await result.update({ state: state })...`
     // did not produce an update to the database. Something about how JSON-type fields are handled?
     // Until we figure this out, just force-update
-    result.story_state = state;
-    result.changed("story_state", true);
+    result.state = state;
+    result.changed("state", true);
     await result.save();
   } else {
-    const storyData = { ...query, story_state: patch };
+    const storyData = { ...query, state: patch };
     result = await StoryState.create(storyData).catch(error => {
       console.log(error);
       return null;

--- a/src/database.ts
+++ b/src/database.ts
@@ -467,7 +467,7 @@ export async function getStages(storyName: string): Promise<Stage[]> {
   });
 }
 
-export async function getStoryState(studentID: number, storyName: string): Promise<JSON | null> {
+export async function getStoryState(studentID: number, storyName: string): Promise<StoryState | null> {
   const result = await StoryState.findOne({
     where: {
       student_id: studentID,
@@ -478,10 +478,10 @@ export async function getStoryState(studentID: number, storyName: string): Promi
     console.log(error);
     return null;
   });
-  return result?.story_state ?? null;
+  return result ?? null;
 }
 
-export async function updateStoryState(studentID: number, storyName: string, newState: JSON): Promise<JSON | null> {
+export async function updateStoryState(studentID: number, storyName: string, newState: JSON): Promise<StoryState | null> {
   const query = {
     student_id: studentID,
     story_name: storyName,
@@ -506,7 +506,7 @@ export async function updateStoryState(studentID: number, storyName: string, new
       return null;
     });
   }
-  return result?.story_state ?? null;
+  return result ?? null;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -525,7 +525,7 @@ function patchState(state: Record<string,any>, patch: Record<string,any>) {
   });
 }
 
-export async function patchStoryState(studentID: number, storyName: string, patch: JSON): Promise<JSON | null> {
+export async function patchStoryState(studentID: number, storyName: string, patch: JSON): Promise<StoryState | null> {
   const query = {
     student_id: studentID,
     story_name: storyName,
@@ -554,7 +554,7 @@ export async function patchStoryState(studentID: number, storyName: string, patc
       return null;
     });
   }
-  return result?.story_state ?? null;
+  return result ?? null;
 }
 
 export async function getStudentStageState(studentID: number, storyName: string, stageName: string): Promise<JSON | null> {

--- a/src/models/story_state.ts
+++ b/src/models/story_state.ts
@@ -5,7 +5,7 @@ import { Student } from "./student";
 export class StoryState extends Model<InferAttributes<StoryState>, InferCreationAttributes<StoryState>> {
   declare student_id: CreationOptional<number>;
   declare story_name: string;
-  declare story_state: JSON;
+  declare state: JSON;
   declare last_modified: CreationOptional<Date>;
 }
 
@@ -29,7 +29,7 @@ export function initializeStoryStateModel(sequelize: Sequelize) {
           key: "name"
         }
       },
-      story_state: {
+      state: {
         type: DataTypes.JSON,
         allowNull: false
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -1662,7 +1662,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
       });
       return;
     }
-    res.json({ state });
+    res.json(state);
   });
 
   /**
@@ -1717,7 +1717,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
       });
       return;
     }
-    res.json({ state });
+    res.json(state);
   });
 
   /**
@@ -1772,7 +1772,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
       });
       return;
     }
-    res.json({ state });
+    res.json(state);
   });
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -1642,40 +1642,27 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
    *          content:
    *            application/json:
    *              schema:
-   *                type: object
-   *                properties:
-   *                  student_id:
-   *                    type: integer
-   *                  story_name:
-   *                    type: string
-   *                  state:
-   *                    description: The story state
-   *                    type: object
+   *                $ref: "#/components/schemas/StoryState" 
    *        404:
    *          description: The student does not have a story state for the given story
    *          content:
    *            application/json:
    *              schema:
-   *                type: object
-   *                properties:
-   *                  student_id:
-   *                    type: integer
-   *                  story_name:
-   *                    type: string
-   *                  state:
-   *                    type: null
+   *                $ref: "#/components/schemas/Error"
+   *
    */
   app.get("/story-state/:studentID/:storyName", async (req, res) => {
     const params = req.params;
     const studentID = Number(params.studentID);
     const storyName = params.storyName;
     const state = await getStoryState(studentID, storyName);
-    const status = state !== null ? 200 : 404;
-    res.status(status).json({
-      student_id: studentID,
-      story_name: storyName,
-      state
-    });
+    if (state === null) {
+      res.status(404).json({
+        error: `No state found for student ${studentID} and story ${storyName}`,
+      });
+      return;
+    }
+    res.json({ state });
   });
 
   /**
@@ -1710,28 +1697,13 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
    *          content:
    *            application/json:
    *              schema:
-   *                type: object
-   *                properties:
-   *                  student_id:
-   *                    type: integer
-   *                  story_name:
-   *                    type: string
-   *                  state:
-   *                    description: The story state
-   *                    type: object
+   *                $ref: "#/components/schemas/StoryState"
    *        500:
-   *          description: The student does not have a story state for the given story
+   *          description: There was an error updating the story state for the given student ID and story name
    *          content:
    *            application/json:
    *              schema:
-   *                type: object
-   *                properties:
-   *                  student_id:
-   *                    type: integer
-   *                  story_name:
-   *                    type: string
-   *                  state:
-   *                    type: null
+   *                $ref: "#/components/schemas/Error"
    */
   app.put("/story-state/:studentID/:storyName", async (req, res) => {
     const params = req.params;
@@ -1739,12 +1711,13 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
     const storyName = params.storyName;
     const newState = req.body;
     const state = await updateStoryState(studentID, storyName, newState);
-    const status = state !== null ? 200 : 500;
-    res.status(status).json({
-      student_id: studentID,
-      story_name: storyName,
-      state
-    });
+    if (state === null) {
+      res.status(500).json({
+        error: `There was an error creating or updating the story state for student ${studentID} and story ${storyName}`,
+      });
+      return;
+    }
+    res.json({ state });
   });
 
   /**
@@ -1779,29 +1752,13 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
    *          content:
    *            application/json:
    *              schema:
-   *                type: object
-   *                properties:
-   *                  student_id:
-   *                    type: integer
-   *                  story_name:
-   *                    type: string
-   *                  state:
-   *                    description: The story state
-   *                    type: object
+   *                $ref: "#/components/schemas/StoryState" 
    *        404:
    *          description: The student does not have a story state for the given story
    *          content:
    *            application/json:
    *              schema:
-   *                type: object
-   *                properties:
-   *                  student_id:
-   *                    type: integer
-   *                  story_name:
-   *                    type: string
-   *                  state:
-   *                    description: The story state
-   *                    type: object
+                    $ref: "#/components/schemas/Error" 
    */
   app.patch("/story-state/:studentID/:storyName", async (req, res) => {
     const params = req.params;
@@ -1809,12 +1766,13 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
     const storyName = params.storyName;
     const patch = req.body;
     const state = await patchStoryState(studentID, storyName, patch);
-    const status = state !== null ? 200 : 404;
-    res.status(status).json({
-      student_id: studentID,
-      story_name: storyName,
-      state
-    });
+    if (state === null) {
+      res.status(404).json({
+        error: `No state found for student ${studentID} and story ${storyName}`,
+      });
+      return;
+    }
+    res.json({ state });
   });
 
   /**

--- a/src/sql/create_story_states_table.sql
+++ b/src/sql/create_story_states_table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE StoryStates (
     student_id int(11) UNSIGNED NOT NULL,
     story_name varchar(50) NOT NULL,
-    story_state JSON NOT NULL,
+    state JSON NOT NULL,
     last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
         ON UPDATE CURRENT_TIMESTAMP,
 

--- a/src/stories/hubbles_law/database.ts
+++ b/src/stories/hubbles_law/database.ts
@@ -469,7 +469,7 @@ export async function getClassDataIDsForStudent(studentID: number): Promise<numb
   const state = (await StoryState.findOne({
     where: { student_id: studentID },
     attributes: [
-      [fn("JSON_EXTRACT", col("story_state"), literal("'$.class_data_students'")), "class_data_students"]
+      [fn("JSON_EXTRACT", col("state"), literal("'$.class_data_students'")), "class_data_students"]
     ]
   }));
   // TODO: Remove the need for ts-ignore here

--- a/tests/story-states.test.ts
+++ b/tests/story-states.test.ts
@@ -25,7 +25,7 @@ async function setupStoryAndStudentStates() {
   const storyState1 = await StoryState.create({
     student_id: student1.id,
     story_name: story.name,
-    story_state: {
+    state: {
       a: 1,
       b: "x",
       flag: true,
@@ -35,7 +35,7 @@ async function setupStoryAndStudentStates() {
   const storyState2 = await StoryState.create({
     student_id: student2.id,
     story_name: story.name,
-    story_state: {
+    state: {
       a: 5,
       b: "y",
       flag: false,
@@ -134,7 +134,7 @@ describe("Test story state routes", () => {
   it("Should correctly update the story state", async () => {
     const { story, student1, storyState2, cleanup } = await setupStoryAndStudentStates();
 
-    const newStoryState = storyState2.story_state;
+    const newStoryState = storyState2.state;
 
     await authorize(request(testApp).put(`/story-state/${student1.id}/${story.name}`))
       .send(newStoryState)

--- a/tests/story-states.test.ts
+++ b/tests/story-states.test.ts
@@ -5,7 +5,7 @@ import request from "supertest";
 import type { Sequelize } from "sequelize";
 import type { Express } from "express";
 
-import { authorize, createTestApp, getTestDatabaseConnection, randomClassForEducator, randomEducator, randomStory, randomStudent } from "./utils";
+import { authorize, createTestApp, expectBodyToMatch, getTestDatabaseConnection, randomClassForEducator, randomEducator, randomStory, randomStudent } from "./utils";
 import { Student, StoryState, StudentsClasses } from "../src/models";
 
 async function setupStoryAndStudentStates() {
@@ -91,10 +91,13 @@ describe("Test story state routes", () => {
       authorize(request(testApp).get(`/story-state/${student.id}/${story.name}`))
         .expect(200)
         .expect("Content-Type", /json/)
-        .expect({
-          student_id: student.id,
-          story_name: story.name,
-          state,
+        .expect(res => {
+          const expected = {
+            student_id: student.id,
+            story_name: story.name,
+            state,
+          };
+          expectBodyToMatch(res, expected);
         });
 
     }
@@ -136,10 +139,13 @@ describe("Test story state routes", () => {
       .send(newStoryState)
       .expect(200)
       .expect("Content-Type", /json/)
-      .expect({
-        student_id: student1.id,
-        story_name: story.name,
-        state: newStoryState,
+      .expect(res => {
+        const expected = {
+          student_id: student1.id,
+          story_name: story.name,
+          state: newStoryState,
+        };
+        expectBodyToMatch(res, expected);
       });
 
     await cleanup();
@@ -158,15 +164,19 @@ describe("Test story state routes", () => {
       .send(patch1)
       .expect(200)
       .expect("Content-Type", /json/)
-      .expect({
-        student_id: student1.id,
-        story_name: story.name,
-        state: {
-          a: 2,
-          b: "w",
-          flag: true,
-          arr: [6, 2, 3, 5],
-        }
+      .expect(res => {
+        const expected = {
+          student_id: student1.id,
+          story_name: story.name,
+          state: {
+            a: 2,
+            b: "w",
+            flag: true,
+            arr: [6, 2, 3, 5],
+          }
+        };
+
+        expectBodyToMatch(res, expected);
       });
 
     const patch2 = {
@@ -179,16 +189,19 @@ describe("Test story state routes", () => {
       .send(patch2)
       .expect(200)
       .expect("Content-Type", /json/)
-      .expect({
-        student_id: student2.id,
-        story_name: story.name,
-        state: {
-          a: 5,
-          b: "y",
-          flag: true,
-          arr: [2, 7],
-          c: "test",
-        }
+      .expect(res => {
+        const expected = {
+          student_id: student2.id,
+          story_name: story.name,
+          state: {
+            a: 5,
+            b: "y",
+            flag: true,
+            arr: [2, 7],
+            c: "test",
+          }
+        };
+        expectBodyToMatch(res, expected);
       });
 
     await cleanup();

--- a/tests/story-states.test.ts
+++ b/tests/story-states.test.ts
@@ -109,9 +109,7 @@ describe("Test story state routes", () => {
       .expect(404)
       .expect("Content-Type", /json/)
       .expect({
-        student_id: badID,
-        story_name: story.name,
-        state: null,
+        error: `No state found for student ${badID} and story ${story.name}`,
       });
 
     await cleanup();
@@ -124,9 +122,7 @@ describe("Test story state routes", () => {
       .expect(404)
       .expect("Content-Type", /json/)
       .expect({
-        student_id: badID,
-        story_name: badStory,
-        state: null,
+        error: `No state found for student ${badID} and story ${badStory}`,
       });
 
   });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import { join } from "path";
 import type { Express } from "express";
 import type { Server } from "http";
-import type { Test } from "supertest";
+import type { Response, Test } from "supertest";
 import { InferAttributes, CreationAttributes, Model, Sequelize, UniqueConstraintError } from "sequelize";
 
 import { setUpAssociations } from "../src/associations";
@@ -293,6 +293,17 @@ export function expectToMatchModel<T extends Model>(object: any, expected: T, ex
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   expect(object).toMatchObject(json);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function expectBodyToMatch(response: Response, expected: any) {
+  // We don't import this from @jest/globals because Jest will throw an error if we try to import a Jest global
+  // outside of the testing environment
+  // But the globals will still be available, so this works
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  expect(response.body).toMatchObject(expected);
 }
 
 export function randomBetween(low: number, high: number) {


### PR DESCRIPTION
For the purposes of API clarity, this PR updates the `/story-state` endpoints to return `StoryState` objects.