### PR TITLE
Updates to temporary file setup

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { Express } from "express";
+import { Express, RequestHandler } from "express";
 import session from "express-session";
 import bodyParser from "body-parser";
 import cookieParser from "cookie-parser";
@@ -16,7 +16,13 @@ import { schemas } from "./openapi/schemas";
 import { COSMICDS_OPENAPI_VERSION, COSMICDS_OPENAPI_APIKEY_SCHEME, COSMICDS_OPENAPI_TAGS } from "./openapi/options";
 import { registerSwaggerDocs } from "./openapi/utils";
 
-export const uploader = multer({ storage: multer.memoryStorage() });
+const MAX_SIZE_MB = 5;
+export const uploader = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_SIZE_MB * 1024 * 1024,
+  }
+});
 
 export function setupApp(app: Express, db: Sequelize) {
 
@@ -72,7 +78,22 @@ export function setupApp(app: Express, db: Sequelize) {
   app.use(apiKeyMiddleware);
 
   // parse requests of content-type - application/json
-  app.use(bodyParser.json());
+  // Skip paths where we aren't going to be uploading JSON
+  // e.g. temporary file paths
+  const jsonParser = bodyParser.json();
+  function skipForEndpoints(endpoints: [string, string[]][]): RequestHandler {
+    return function (req, res, next) {
+      for (const [path, methods] of endpoints) {
+        if (req.path.startsWith(path) && methods.some(method => req.method.toLowerCase() == method)) {
+          return next();
+        }
+      }
+      return jsonParser(req, res, next);
+    }
+  }
+  app.use(skipForEndpoints([
+    ["/temp", ["post", "patch"]],
+  ]));
 
   // parse requests of content-type - application/x-www-form-urlencoded
   app.use(bodyParser.urlencoded({ extended: true }));

--- a/src/app.ts
+++ b/src/app.ts
@@ -89,7 +89,7 @@ export function setupApp(app: Express, db: Sequelize) {
         }
       }
       return jsonParser(req, res, next);
-    }
+    };
   }
   app.use(skipForEndpoints([
     ["/temp", ["post", "patch"]],

--- a/src/server.ts
+++ b/src/server.ts
@@ -2611,7 +2611,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
 
   /**
    * @openapi
-   * /temp/{uuid}
+   * /temp/{uuid}:
    *   patch:
    *     tags:
    *       - temporary
@@ -2740,7 +2740,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
     *     200:
     *       description: The requested temporary file exists and its content has been returned. The MIME type will match the file's contents.
     *       content:
-    *         * / *:
+    *         application/octet-stream:
     *           schema:
     *             type: string
     *             format: binary
@@ -2757,7 +2757,7 @@ export function createApp(db: Sequelize, options?: AppOptions): Express {
     *           schema:
     *             $ref: "#/components/schemas/Error"
     *       
-   */
+    */
   app.get("/temp/:uuid", async (req, res) => {
     const uuid = req.params.uuid;
     if (!validateUUID(uuid)) {


### PR DESCRIPTION
This PR contains some updates to the temporary file setup, namely:
- Skip body-parser on the upload and update endpoints
- Set the multer max size limit to 5 MB
- Fix some issues in the OpenAPI spec comments