### PR TITLE
Allow getting temporary files without an API key

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,8 @@ export async function apiKeyMiddleware(req: Request, res: ExpressResponse, next:
     ||
   req.path.startsWith("/docs")
     ||
+  (req.path.startsWith("/temp") && req.method.toLowerCase() == "get")
+    ||
   /docs(.json)?/.test(req.path);
 
   if (noKeyNeeded) {


### PR DESCRIPTION
This PR allows accessing temporary file content without an API key. We need this for our initial intended use case (saving files to Google Drive), and I don't think we're ever going to want anyone to put anything sensitive inside of temporary files.