### PR TITLE
Add temporary tag to OpenAPI schema

### DIFF
--- a/src/openapi/options.ts
+++ b/src/openapi/options.ts
@@ -25,6 +25,10 @@ export const COSMICDS_OPENAPI_TAGS: Tag[] = [
     name: "questions",
     description: "Operations related to managing questions",
   },
+  {
+    name: "temporary",
+    description: "Operations related to managing temporary files in the CosmicDS database.",
+  },
 ];
 
 export const COSMICDS_OPENAPI_APIKEY_SCHEME: SecurityScheme = {


### PR DESCRIPTION
While working on #301, #302, #303, I forgot to add a description of the temporary tag in the OpenAPI schema. This PR fixes that.